### PR TITLE
Update package.json to exact version match

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2209,7 +2209,7 @@
     },
     "vscode-languageserver": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-4.1.2.tgz",
+      "resolved": "http://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-4.1.2.tgz",
       "integrity": "sha512-3iej2tuMaI9yirPXF7/fVyIvBhSzbwZ3EWFRb8bP6lc3tGv9SJHDaJLNyQMgo9J8CNpXil6dWarpJvGSA60v/w==",
       "requires": {
         "vscode-languageserver-protocol": "3.7.1",

--- a/package.json
+++ b/package.json
@@ -26,26 +26,26 @@
     "url": "https://github.com/Microsoft/azure-pipelines-language-server.git"
   },
   "dependencies": {
-    "js-yaml": "^3.12.0",
-    "jsonc-parser": "^1.0.3",
-    "request-light": "^0.2.3",
+    "js-yaml": "3.12.0",
+    "jsonc-parser": "1.0.3",
+    "request-light": "0.2.3",
     "vscode-json-languageservice": "3.0.12",
-    "vscode-languageserver": "^4.0.0",
-    "vscode-languageserver-types": "^3.6.1",
-    "vscode-nls": "^3.2.2",
+    "vscode-languageserver": "4.1.2",
+    "vscode-languageserver-types": "3.6.1",
+    "vscode-nls": "3.2.2",
     "vscode-uri": "1.0.3",
     "yaml-ast-parser": "0.0.40"
   },
   "devDependencies": {
     "@types/mocha": "5.2.5",
-    "@types/node": "^9.4.7",
-    "coveralls": "^3.0.0",
+    "@types/node": "9.6.6",
+    "coveralls": "3.0.0",
     "mocha": "5.2.0",
-    "mocha-lcov-reporter": "^1.3.0",
-    "nyc": "^13.0.1",
-    "source-map-support": "^0.5.4",
-    "ts-node": "^5.0.1",
-    "typescript": "^2.7.2"
+    "mocha-lcov-reporter": "1.3.0",
+    "nyc": "13.0.1",
+    "source-map-support": "0.5.5",
+    "ts-node": "5.0.1",
+    "typescript": "2.7.2"
   },
   "scripts": {
     "compile": "tsc -p .",


### PR DESCRIPTION
 - use exact version match in package.json
 - the best npm version that works without generating ^versions in package-lock is 5.10
