### PR TITLE
Proposals for additions to the schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The following settings are supported:
 * `yaml.schemas`: Helps you associate schemas with files in a glob pattern
 * `yaml.customTags`: Array of custom tags that the parser will validate against. It has two ways to be used. Either an item in the array is a custom tag such as "!Ref" or you can specify the type of the object !Ref should be by doing "!Ref scalar". For example: ["!Ref", "!Some-Tag scalar"]. The type of object can be one of scalar, sequence, mapping, map.
 
-##### Associating a schema to a glob pattern via yaml.schemas: 
+##### Associating a schema to a glob pattern via yaml.schemas:
 When associating a schema it should follow the format below
 ```
 yaml.schemas: {
@@ -67,13 +67,6 @@ yaml.schemas: {
 
 `yaml.schemas` extension allows you to specify json schemas that you want to validate against the yaml that you write. Kubernetes and kedge are optional fields. They do not require a url as the language server will provide that. You just need the keywords kubernetes/kedge and a glob pattern.
 
-## Clients
-This repository only contains the server implementation. Here are some known clients consuming this server:
-
-* [Eclipse Che](https://www.eclipse.org/che/)
-* [vscode-yaml](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) for VSCode
-* [ide-yaml](https://atom.io/packages/ide-yaml) for Atom editor
-
 ## Developer Support
 
 This repo consists of 2 separate projects/packages:
@@ -81,14 +74,14 @@ This repo consists of 2 separate projects/packages:
 2. * [azure-pipelines-language-server](https://github.com/Microsoft/azure-pipelines-language-server/tree/master/language-server) - language server implementation that dependes on azure-pipelines-language-service
 
 In order to tighten the dev loop you can utilize `npm link` that will sync changes to service package without re-installing.
- 
+
  1. First install dependencies for both service and server:
     * `cd language-service`
     * `npm install`
     * `npm run build`
     * `cd ../language-server`
     * `npm install`
-    * `npm run build` 
+    * `npm run build`
 2. Link languageservice/out/src to the global folder and connect it to the language-server's node_modules
     * `cd ../language-service/out/src`
     * `npm link`

--- a/docs/schema-extensions.md
+++ b/docs/schema-extensions.md
@@ -61,6 +61,44 @@ Its behavior is identical to `enum` except that on validation, any casing of the
 When Intellisense is requested, "Foo@1" and "Bar@1" will be suggested.
 For validation, "foo@1", "Foo@1", "FOO@1", "fOo@1", and any other capitalization are accepted.
 
+## Case-insensitive keywords
+
+In Azure Pipelines YAML, inputs to tasks are case-insensitive.
+Like `enum`s, it's convenient to represent these in a canonical form used for suggestion, but accept any casing for validation.
+
+```yaml
+# In Azure Pipelines, the two steps are equivalent:
+steps:
+- task: Foo@1
+  inputs:
+    Bar: Baz
+- task: Foo@1
+  inputs:
+    bar: Baz
+```
+
+We introduce a new validation keyword, `ignoreCase`.
+
+```json
+{
+    "properties": {
+        "foo": {
+            "type": "string",
+            "ignoreCase": true
+        },
+        "bar": {
+            "type": "int",
+            "ignoreCase": true
+        }
+    },
+    "additionalProperties": false,
+    ...
+}
+```
+
+For validation purposes, any of "foo", "FOO", "Foo", "fOo", etc. are accepted as keywords.
+For Intellisense suggestion purposes, only the canonical form is suggested.
+
 ## Initial key in a mapping
 
 YAML mappings are unordered.

--- a/docs/schema-extensions.md
+++ b/docs/schema-extensions.md
@@ -1,0 +1,72 @@
+# Proposed schema extensions
+
+The Azure Pipelines YAML format includes 3 non-standard features of YAML.
+With appropriate schema support, they should be possible to support in this language server.
+Fortunately, JSON Schema allows extension.
+
+## Initial key in a mapping
+
+YAML mappings are unordered.
+But, for security and performance reasons, some Azure Pipelines objects require that a particular key appear first.
+This tells the parser what remaining keywords are acceptable.
+
+```yaml
+# In standard YAML, these two constructs are equivalent:
+
+- keyA: valueA
+  keyB: valueB
+
+- keyB: valueB
+  keyA: valueA
+
+# In Azure Pipelines YAML, these two constructs are not equivalent:
+- task: Foo@1
+  displayName: Foo Task
+
+- displayName: Foo Task # not valid: "task" must appear first
+  task: Foo@1
+
+# NB: `task` has peers like `script`, `bash`, and others that must be
+#     recognized in a oneOf context
+```
+
+Normal JSON Schema to validate the above:
+
+```json
+{
+    "properties": {
+        "task": {
+            "type": "string",
+            "pattern": "^[A-Za-z_.]+@[0-9]+$"
+        },
+        "displayName": {
+            "type": "string"
+        }
+    },
+    "additionalProperties": false,
+    ...
+}
+```
+
+In order to support the notion that one key has to appear first, both for validation and Intellisense suggestions, we introduce a schema extension `firstProperty`.
+
+```json
+{
+    "properties": {
+        "task": {
+            "type": "string",
+            "pattern": "^[A-Za-z_.]+@[0-9]+$"
+        },
+        "displayName": {
+            "type": "string"
+        }
+    },
+    "additionalProperties": false,
+    "firstProperty": "task"  // new construct
+    ...
+}
+```
+
+This schema only validates if the `firstProperty` keyword appears first.
+For Intellisense suggestions, if the `firstProperty` keyword hasn't already been recognized at this level, only it will be suggested.
+This latter behavior aggregates: if an `anyOf` construct includes several schema branches with `firstProperty` indicators, the set of those will be offered for Intellisense.

--- a/docs/schema-extensions.md
+++ b/docs/schema-extensions.md
@@ -97,7 +97,7 @@ This schema only validates if the `firstProperty` keyword appears first.
 For Intellisense suggestions, if the `firstProperty` keyword hasn't already been recognized at this level, only it will be suggested.
 This latter behavior aggregates: if an `anyOf` construct includes several schema branches with `firstProperty` indicators, the set of those will be offered for Intellisense.
 
-## Multiple keys
+## Duplicate keys
 
 In standard YAML, keys may not be duplicated.
 In Azure Pipelines YAML, we allow identical keys if they are template expressions beginning with `if`.

--- a/docs/schema-extensions.md
+++ b/docs/schema-extensions.md
@@ -31,6 +31,36 @@ In order to retain validation but suppress Intellisense suggestions, we introduc
 If not present, `suggest` defaults to `true`.
 If present and set to `false`, the marked keyword is never suggested in Intellisense.
 
+## Case-insensitive enums
+
+Azure Pipelines YAML has several places where values are case-insensitive.
+It's convenient to represent them with an enum which describes their canonical case for purposes of Intellisense / auto-complete.
+Regardless of case, though, they should validate.
+
+```yaml
+# In Azure Pipelines, the steps are all equivalent:
+steps:
+- task: Foo@1
+- task: FOO@1
+- task: foo@1
+```
+
+We introduce a new type, `enumCaseInsensitive`.
+Its behavior is identical to `enum` except that on validation, any casing of the word is accepted.
+
+```json
+{
+    "properties": {
+        "task": {
+            "enum": ["Foo@1", "Bar@1"]
+        },
+        ...
+    }
+```
+
+When Intellisense is requested, "Foo@1" and "Bar@1" will be suggested.
+For validation, "foo@1", "Foo@1", "FOO@1", "fOo@1", and any other capitalization are accepted.
+
 ## Initial key in a mapping
 
 YAML mappings are unordered.

--- a/docs/schema-extensions.md
+++ b/docs/schema-extensions.md
@@ -12,7 +12,6 @@ This tells the parser what remaining keywords are acceptable.
 
 ```yaml
 # In standard YAML, these two constructs are equivalent:
-
 - keyA: valueA
   keyB: valueB
 
@@ -70,3 +69,38 @@ In order to support the notion that one key has to appear first, both for valida
 This schema only validates if the `firstProperty` keyword appears first.
 For Intellisense suggestions, if the `firstProperty` keyword hasn't already been recognized at this level, only it will be suggested.
 This latter behavior aggregates: if an `anyOf` construct includes several schema branches with `firstProperty` indicators, the set of those will be offered for Intellisense.
+
+## Multiple keys
+
+In standard YAML, keys may not be duplicated.
+In Azure Pipelines YAML, we allow identical keys if they are template expressions beginning with `if`.
+
+```yaml
+# In standard YAML, illegal:
+- keyA: valueA
+  keyA: valueB
+
+# In Azure Pipelines YAML, legal:
+steps:
+- ${{ if(eq("parameters.platform", "macOS")) }}:
+  - script: echo Pre-step, only on Mac
+- script: echo Middle step, always
+- ${{ if(eq("parameters.platform", "macOS")) }}:
+  - script: echo Post-step, only on Mac
+```
+
+In order to support duplication of keys, we introduce an `allowMultiple` declaration.
+
+```json
+{
+    "patternProperties": {
+        "\$\{\{.*\}\}": {
+            "allowMultiple": true,  // new construct
+            ...
+        }
+    },
+    ...
+```
+
+Multiple instances of a property marked `allowMultiple` are not a validation error.
+Intellisense behavior is TBD.

--- a/docs/schema-extensions.md
+++ b/docs/schema-extensions.md
@@ -1,8 +1,35 @@
 # Proposed schema extensions
 
-The Azure Pipelines YAML format includes 3 non-standard features of YAML.
+The Azure Pipelines YAML format includes several non-standard features of YAML.
 With appropriate schema support, they should be possible to support in this language server.
 Fortunately, JSON Schema allows extension.
+
+## Obsolete items
+
+Some constructions in Azure Pipelines YAML are valid but no longer preferred.
+They should not be suggested by Intellisense, but should be validated if present.
+
+```yaml
+# In Azure Pipelines YAML, the below is valid but not preferred:
+queue: Hosted VS2017
+```
+
+In order to retain validation but suppress Intellisense suggestions, we introduce the `suggest` extension.
+
+```json
+{
+    "properties": {
+        "queue": {
+            "type": "string",
+            "suggest": false,
+            ...
+        }
+    }
+}
+```
+
+If not present, `suggest` defaults to `true`.
+If present and set to `false`, the marked keyword is never suggested in Intellisense.
 
 ## Initial key in a mapping
 


### PR DESCRIPTION
Azure Pipelines YAML has some nonstandard behaviors. We need to accommodate these in the language server and express them via schema.

- Obsolete items
- Requiring a particular mapping key to appear first
- Allowing duplicate keys