### PR TITLE
Fix completion suggestions bug on empty lines

### DIFF
--- a/language-service/CHANGELOG.md
+++ b/language-service/CHANGELOG.md
@@ -1,3 +1,6 @@
+#### 0.2.2
+Fix the completion suggestions on empty line bug [#PR-12](https://github.com/Microsoft/azure-pipelines-language-server/pull/12)
+
 #### 0.2.1
 Fixes to use consistent types in language-service, added webpack to generate UMD bundle [#PR-9](https://github.com/Microsoft/azure-pipelines-language-server/pull/9)
 

--- a/language-service/package.json
+++ b/language-service/package.json
@@ -1,9 +1,11 @@
 {
   "name": "azure-pipelines-language-service",
   "description": "Azure Pipelines language service",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "author": "Microsoft",
   "license": "MIT",
+  "main": "./lib/src/index.js",
+  "typings": "./lib/src/index",
   "contributors": [
     {
       "name": "Stephen Franceschelli",

--- a/language-service/src/utils/yamlServiceUtils.ts
+++ b/language-service/src/utils/yamlServiceUtils.ts
@@ -18,7 +18,7 @@ export function completionHelper(document: TextDocument, textDocumentPosition: P
         end = document.getText().length;
     }
 
-    while (end - 1 >= start && is_EOL(document.getText().charCodeAt(end - 1))) {
+    while (end - 1 >= 0 && is_EOL(document.getText().charCodeAt(end - 1))) {
         end--;
     }
 


### PR DESCRIPTION
`completionHelper` has a bug that allows end index to be lower than start index for substring. #9 fixes this problem but turns out that bug has a positive side effect that makes completion work on empty lines.
I am still trying to understand why we need this completion helper hack so for now I am just reverting my change to `completionHelper`.

Also adding "main" and "typings" to the package.json to simplify integration with this package.