### PR TITLE
consume version 0.4.1 of language-service and fix several unit tests

### DIFF
--- a/language-server/package-lock.json
+++ b/language-server/package-lock.json
@@ -216,9 +216,9 @@
       "dev": true
     },
     "azure-pipelines-language-service": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-language-service/-/azure-pipelines-language-service-0.4.0.tgz",
-      "integrity": "sha512-BnRPd+ngnh1q8rJUawLaqlU5nxisruSPkpQ0GZ+IMukI6yJibIcJA8dmlW/iOE6Be3jfyFN9jPRJUqFmTvPbog==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-language-service/-/azure-pipelines-language-service-0.4.1.tgz",
+      "integrity": "sha512-VIPeKrbEyhmRaDrfYNjNmQqIbMREXqi7nuX5VerPMp1J6wWLnWmTwMn+33GCvAlhXSNjtboKmOtbZyu1L+U1Qw==",
       "requires": {
         "js-yaml": "3.12.0",
         "jsonc-parser": "2.0.2",

--- a/language-server/package.json
+++ b/language-server/package.json
@@ -30,7 +30,7 @@
     "url": "https://github.com/Microsoft/azure-pipelines-language-server.git"
   },
   "dependencies": {
-    "azure-pipelines-language-service": "0.4.0",
+    "azure-pipelines-language-service": "0.4.1",
     "request-light": "0.2.3",
     "vscode-languageserver": "4.1.2",
     "vscode-languageserver-types": "3.6.1",

--- a/language-server/test/autoCompletion.test.ts
+++ b/language-server/test/autoCompletion.test.ts
@@ -28,103 +28,107 @@ suite("Auto Completion Tests", () => {
 		describe('doComplete', function(){
 
 			function parseSetup(content: string, position){
-				let document = TextDocument.create("file://~/Desktop/vscode-k8s/test.yaml", "yaml", 0, content);
-				let completion = completionHelper(document, document.positionAt(position));
-				let jsonDocument = parseYAML(completion.newText);
+				const document = TextDocument.create("file://~/Desktop/vscode-k8s/test.yaml", "yaml", 0, content);
+				const completion = completionHelper(document, document.positionAt(position));
+				const jsonDocument = parseYAML(completion.newText);
 				return languageService.doComplete(document, completion.newPosition, jsonDocument);
 			}
 
 			it('Autocomplete on root node without word', (done) => {
-				let content = "";
-				let completion = parseSetup(content, 0);
+				const content: string = "";
+				const completion = parseSetup(content, content.length);
 				completion.then(function(result){
                     assert.notEqual(result.items.length, 0);
 				}).then(done, done);
 			});
 
 			it('Autocomplete on root node with word', (done) => {
-				let content = "analyt";
-				let completion = parseSetup(content, 6);
+				const content: string = "analyt";
+				const completion = parseSetup(content, content.length);
 				completion.then(function(result){
 					assert.notEqual(result.items.length, 0);
 				}).then(done, done);
 			});
 
 			it('Autocomplete on default value (without value content)', (done) => {
-				let content = "directory: ";
-				let completion = parseSetup(content, 12);
+				const content: string = "directory: ";
+				const completion = parseSetup(content, content.length);
 				completion.then(function(result){
 					assert.notEqual(result.items.length, 0);
 				}).then(done, done);
 			});
 
 			it('Autocomplete on default value (with value content)', (done) => {
-				let content = "directory: bow";
-				let completion = parseSetup(content, 15);
+				const content: string = "directory: bow";
+				const completion = parseSetup(content, content.length);
 				completion.then(function(result){
 					assert.notEqual(result.items.length, 0);
 				}).then(done, done);
 			});
 
 			it('Autocomplete on boolean value (without value content)', (done) => {
-				let content = "analytics: ";
-				let completion = parseSetup(content, 11);
+				const content: string = "analytics: ";
+				const completion = parseSetup(content, content.length);
 				completion.then(function(result){
 					assert.equal(result.items.length, 2);
 				}).then(done, done);
 			});
 
 			it('Autocomplete on boolean value (with value content)', (done) => {
-				let content = "analytics: fal";
-				let completion = parseSetup(content, 11);
+				const content: string = "analytics: fal";
+				const completion = parseSetup(content, content.length);
 				completion.then(function(result){
 					assert.equal(result.items.length, 2);
 				}).then(done, done);
 			});
 
 			it('Autocomplete on number value (without value content)', (done) => {
-				let content = "timeout: ";
-				let completion = parseSetup(content, 9);
+				const content: string = "timeout: ";
+				const completion = parseSetup(content, content.length);
 				completion.then(function(result){
 					assert.equal(result.items.length, 1);
 				}).then(done, done);
 			});
 
 			it('Autocomplete on number value (with value content)', (done) => {
-				let content = "timeout: 6";
-				let completion = parseSetup(content, 10);
+				const content: string = "timeout: 6";
+				const completion = parseSetup(content, content.length);
 				completion.then(function(result){
 					assert.equal(result.items.length, 1);
 				}).then(done, done);
 			});
 
 			it('Autocomplete key in middle of file', (done) => {
-				let content = "scripts:\n  post";
-				let completion = parseSetup(content, 11);
+				const preCursorContent: string = "scripts:\n  po";
+				const postCursorConent: string = "st";
+				const completion = parseSetup(preCursorContent + postCursorConent, preCursorContent.length);
 				completion.then(function(result){
 					assert.notEqual(result.items.length, 0);
 				}).then(done, done);
 			});
 
 			it('Autocomplete key in middle of file 2', (done) => {
-				let content = "scripts:\n  postinstall: /test\n  preinsta";
-				let completion = parseSetup(content, 31);
+				const preCursorContent: string = "scripts:\n  postinstall: /test\n  pr"
+				const postCursorContent: string = "einsta";
+				const completion = parseSetup(preCursorContent + postCursorContent, preCursorContent.length);
 				completion.then(function(result){
 					assert.notEqual(result.items.length, 0);
 				}).then(done, done);
 			});
 
-			it('Autocomplete does not happen right after :', (done) => {
-				let content = "analytics:";
-				let completion = parseSetup(content, 9);
+			it('Autocomplete does not happen right before :', (done) => {
+				const preCursorContent: string = "analytics";
+				const postCursorContent: string = ":";
+				const completion = parseSetup(preCursorContent + postCursorContent, preCursorContent.length);
 				completion.then(function(result){
 					assert.notEqual(result.items.length, 0);
 				}).then(done, done);
 			});
 
-			it('Autocomplete does not happen right after : under an object', (done) => {
-				let content = "scripts:\n  postinstall:";
-				let completion = parseSetup(content, 21);
+			it('Autocomplete does not happen right before : under an object', (done) => {
+				const preCursorContent: string = "scripts:\n  postinstall";
+				const postCursorContent: string = ":";
+				const completion = parseSetup(preCursorContent + postCursorContent, preCursorContent.length);
 				completion.then(function(result){
 					assert.notEqual(result.items.length, 0);
 				}).then(done, done);

--- a/language-server/test/autoCompletion.test.ts
+++ b/language-server/test/autoCompletion.test.ts
@@ -129,22 +129,6 @@ suite("Auto Completion Tests", () => {
 					assert.notEqual(result.items.length, 0);
 				}).then(done, done);
 			});
-
-			it('Autocomplete on multi yaml documents in a single file on root', (done) => {
-				let content = `---\nanalytics: true\n...\n---\n...`;
-				let completion = parseSetup(content, 28);
-				completion.then(function(result){
-					assert.notEqual(result.items.length, 0);
-				}).then(done, done);
-			});
-
-			it('Autocomplete on multi yaml documents in a single file on scalar', (done) => {
-				let content = `---\nanalytics: true\n...\n---\njson: \n...`;
-				let completion = parseSetup(content, 34);
-				completion.then(function(result){
-					assert.notEqual(result.items.length, 0);
-				}).then(done, done);
-			});
 		});
 	});
 });

--- a/language-server/test/autoCompletion2.test.ts
+++ b/language-server/test/autoCompletion2.test.ts
@@ -35,7 +35,7 @@ suite("Auto Completion Tests", () => {
 
 			it('Array autocomplete without word', (done) => {
 				let content = "authors:\n  - ";
-				let completion = parseSetup(content, 14);
+				let completion = parseSetup(content, content.length);
 				completion.then(function(result){
 					assert.notEqual(result.items.length, 0);
 				}).then(done, done);
@@ -43,7 +43,7 @@ suite("Auto Completion Tests", () => {
 
 			it('Array autocomplete with letter', (done) => {
 				let content = "authors:\n  - n";
-				let completion = parseSetup(content, 14);
+				let completion = parseSetup(content, content.length);
 				completion.then(function(result){
 					assert.notEqual(result.items.length, 0);
 				}).then(done, done);
@@ -51,7 +51,7 @@ suite("Auto Completion Tests", () => {
 
 			it('Array autocomplete without word (second item)', (done) => {
 				let content = "authors:\n  - name: test\n    ";
-				let completion = parseSetup(content, 32);
+				let completion = parseSetup(content, content.length);
 				completion.then(function(result){
 					assert.notEqual(result.items.length, 0);
 				}).then(done, done);
@@ -59,7 +59,7 @@ suite("Auto Completion Tests", () => {
 
 			it('Array autocomplete with letter (second item)', (done) => {
 				let content = "authors:\n  - name: test\n    e";
-				let completion = parseSetup(content, 27);
+				let completion = parseSetup(content, content.length);
 				completion.then(function(result){
 					assert.notEqual(result.items.length, 0);
 				}).then(done, done);
@@ -67,7 +67,7 @@ suite("Auto Completion Tests", () => {
 
 			it('Autocompletion after array', (done) => {
 				let content = "authors:\n  - name: test\n"
-				let completion = parseSetup(content, 24);
+				let completion = parseSetup(content, content.length);
 				completion.then(function(result){
 					assert.notEqual(result.items.length, 0);
 				}).then(done, done);
@@ -75,7 +75,7 @@ suite("Auto Completion Tests", () => {
 
 			it('Autocompletion after array with depth', (done) => {
 				let content = "archive:\n  exclude:\n  - test\n"
-				let completion = parseSetup(content, 29);
+				let completion = parseSetup(content, content.length);
 				completion.then(function(result){
 					assert.notEqual(result.items.length, 0);
 				}).then(done, done);
@@ -83,7 +83,7 @@ suite("Auto Completion Tests", () => {
 
 			it('Autocompletion after array with depth', (done) => {
 				let content = "autoload:\n  classmap:\n  - test\n  exclude-from-classmap:\n  - test\n  "
-				let completion = parseSetup(content, 70);
+				let completion = parseSetup(content, content.length);
 				completion.then(function(result){
 					assert.notEqual(result.items.length, 0);
 				}).then(done, done);
@@ -95,7 +95,7 @@ suite("Auto Completion Tests", () => {
 
 			it('Autocompletion has no results on value when they are not available', (done) => {
 				let content = "time: "
-				let completion = parseSetup(content, 6);
+				let completion = parseSetup(content, content.length);
 				completion.then(function(result){
 					assert.equal(result.items.length, 0);
 				}).then(done, done);
@@ -103,7 +103,7 @@ suite("Auto Completion Tests", () => {
 
 			it('Autocompletion has no results on value when they are not available (with depth)', (done) => {
 				let content = "archive:\n  exclude:\n    - test\n    "
-				let completion = parseSetup(content, 33);
+				let completion = parseSetup(content, content.length);
 				completion.then(function(result){
 					assert.equal(result.items.length, 0);
 				}).then(done, done);
@@ -111,7 +111,7 @@ suite("Auto Completion Tests", () => {
 
 			it('Autocompletion does not complete on wrong spot in array node', (done) => {
 				let content = "authors:\n  - name: test\n  "
-				let completion = parseSetup(content, 24);
+				let completion = parseSetup(content, content.length);
 				completion.then(function(result){
 					assert.equal(result.items.length, 0);
 				}).then(done, done);

--- a/language-server/test/documentSymbols.test.ts
+++ b/language-server/test/documentSymbols.test.ts
@@ -86,14 +86,5 @@ suite("Document Symbols Tests", () => {
             assert.equal(symbols.length, 6);	
             done();			
         });
-
-        it('Document Symbols with multi documents', (done) => {
-            let content = '---\nanalytics: true\n...\n---\njson: test\n...';
-            let symbols = parseSetup(content);
-            assert.equal(symbols.length, 2);	
-            done();			
-        });
-
     });
-    
 });

--- a/language-server/test/hover.test.ts
+++ b/language-server/test/hover.test.ts
@@ -118,14 +118,6 @@ suite("Hover Tests", () => {
 					assertHasContents(result);
 				}).then(done, done);
 			});
-			
-			it('Hover on multi document', (done) => {
-				let content: string = '---\nanalytics: true\n...\n---\njson: test\n...';
-				let hover: Thenable<Hover> = parseSetup(content, 30);
-				hover.then(function(result: Hover){
-					assertHasContents(result);
-				}).then(done, done);
-            });
 		});
 	});
 });

--- a/language-server/test/integration.test.ts
+++ b/language-server/test/integration.test.ts
@@ -124,7 +124,7 @@ suite("Kubernetes Integration Tests", () => {
 
 		describe('Test that validation DOES throw errors', function(){
 			it('Error when theres no value for a node', (done) => {
-				let content = `apiVersion:`;
+				let content = `isNonResourceURL:`;
 				let validator = parseSetup(content);
 				validator.then(function(result){
 					assert.notEqual(result.length, 0);
@@ -155,14 +155,6 @@ suite("Kubernetes Integration Tests", () => {
 				}).then(done, done);
 			});
 
-			it('Error on incorrect value type in multiple yaml documents', (done) => {
-				let content = `---\napiVersion: v1\n...\n---\napiVersion: False\n...`;
-				let validator = parseSetup(content);
-				validator.then(function(result){
-					assert.notEqual(result.length, 0);
-				}).then(done, done);
-			});
-
 			it('Property error message should be \"Unexpected property {$property_name}\" when property is not allowed ', (done) => {
 				let content = `unknown_node: test`;
 				let validator = parseSetup(content);
@@ -171,9 +163,7 @@ suite("Kubernetes Integration Tests", () => {
 					assert.equal(result[0].message, "Unexpected property unknown_node");
 				}).then(done, done);
 			});
-
 		});
-
 	});
 
 	describe('yamlCompletion with kubernetes', function(){

--- a/language-server/test/schemaValidation.test.ts
+++ b/language-server/test/schemaValidation.test.ts
@@ -202,7 +202,7 @@ suite("Validation Tests", () => {
 			});
 
 			it('Error when theres no value for a node', (done) => {
-				let content = `cwd:`;
+				let content = `storage:`;
 				let validator = parseSetup(content);
 				validator.then(function(result){
 					assert.notEqual(result.length, 0);


### PR DESCRIPTION
removed all multi-document unit tests since azure pipelines doesn't support multi-document files (see https://github.com/Microsoft/azure-pipelines-vscode/issues/177 )

fixed tests that were sensitive to line ending type (1 vs 2 bytes mixed with literal offsets)

changed tests that were expecting errors from empty strings to look for other data types since we now allow empty strings