### PR TITLE
do not call localize during auto-complete

### DIFF
--- a/language-service/CHANGELOG.md
+++ b/language-service/CHANGELOG.md
@@ -1,6 +1,7 @@
 
 #### 0.5.2
 Fix a regression with YAML structure errors [#PR-49](https://github.com/Microsoft/azure-pipelines-language-server/pull/49)
+Improve performance
 
 #### 0.5.1
 version 0.5.0 was not built correctly

--- a/language-service/CHANGELOG.md
+++ b/language-service/CHANGELOG.md
@@ -1,7 +1,7 @@
 
 #### 0.5.2
 Fix a regression with YAML structure errors [#PR-49](https://github.com/Microsoft/azure-pipelines-language-server/pull/49)
-Improve performance
+Improve performance [#PR-50](https://github.com/Microsoft/azure-pipelines-language-server/pull/50)
 
 #### 0.5.1
 version 0.5.0 was not built correctly

--- a/language-service/src/parser/jsonParser.ts
+++ b/language-service/src/parser/jsonParser.ts
@@ -33,7 +33,7 @@ export interface IProblem {
 	location: IRange;
 	severity: ProblemSeverity;
 	code?: ErrorCode;
-	messageFunction: () => string;
+	getMessage: () => string;
 }
 
 export class ASTNode {
@@ -178,7 +178,7 @@ export class ASTNode {
 					validationResult.problems.push({
 						location: { start: this.start, end: this.end },
 						severity: ProblemSeverity.Warning,
-						messageFunction: () => { return schema.errorMessage || localize('typeArrayMismatchWarning', 'Incorrect type. Expected one of {0}.', (<string[]>schema.type).join(', ')); }
+						getMessage: () => schema.errorMessage || localize('typeArrayMismatchWarning', 'Incorrect type. Expected one of {0}.', (<string[]>schema.type).join(', '))
 					});
 				}
 			}
@@ -190,7 +190,7 @@ export class ASTNode {
 					validationResult.problems.push({
 						location: { start: this.start, end: this.end },
 						severity: ProblemSeverity.Warning,
-						messageFunction: () => { return schema.errorMessage || localize('typeMismatchWarning', 'Incorrect type. Expected "{0}".', schema.type); }
+						getMessage: () => schema.errorMessage || localize('typeMismatchWarning', 'Incorrect type. Expected "{0}".', schema.type)
 					});
 				}
 			}
@@ -208,7 +208,7 @@ export class ASTNode {
 				validationResult.problems.push({
 					location: { start: this.start, end: this.end },
 					severity: ProblemSeverity.Warning,
-					messageFunction: () => { return localize('notSchemaWarning', "Matches a schema that is not allowed."); }
+					getMessage: () => localize('notSchemaWarning', "Matches a schema that is not allowed.")
 				});
 			}
 			subMatchingSchemas.schemas.forEach((ms) => {
@@ -243,7 +243,7 @@ export class ASTNode {
 				validationResult.problems.push({
 					location: { start: this.start, end: this.start + 1 },
 					severity: ProblemSeverity.Warning,
-					messageFunction: () => { return localize('oneOfWarning', "Matches multiple schemas when only one must validate."); }
+					getMessage: () => localize('oneOfWarning', "Matches multiple schemas when only one must validate.")
 				});
 			}
 
@@ -286,7 +286,7 @@ export class ASTNode {
 					location: { start: this.start, end: this.end },
 					severity: ProblemSeverity.Warning,
 					code: ErrorCode.EnumValueMismatch,
-					messageFunction: () => { return schema.errorMessage || localize('enumWarning', 'Value is not accepted. Valid values: {0}.', schema.enum.map(v => JSON.stringify(v)).join(', ')); }
+					getMessage: () => schema.errorMessage || localize('enumWarning', 'Value is not accepted. Valid values: {0}.', schema.enum.map(v => JSON.stringify(v)).join(', '))
 				});
 			}
 		}
@@ -295,7 +295,7 @@ export class ASTNode {
 			validationResult.problems.push({
 				location: { start: this.parent.start, end: this.parent.end },
 				severity: ProblemSeverity.Hint,
-				messageFunction: () => { return schema.deprecationMessage; }
+				getMessage: () => schema.deprecationMessage
 			});
 		}
 
@@ -307,7 +307,7 @@ export class ASTNode {
 			validationResult.problems.push({
 				location: { start: this.start, end: this.end },
 				severity: ProblemSeverity.Warning,
-				messageFunction: () => { return localize('minLengthWarning', 'String is shorter than the minimum length of {0}.', schema.minLength); }
+				getMessage: () => localize('minLengthWarning', 'String is shorter than the minimum length of {0}.', schema.minLength)
 			});
 		}
 	
@@ -315,7 +315,7 @@ export class ASTNode {
 			validationResult.problems.push({
 				location: { start: this.start, end: this.end },
 				severity: ProblemSeverity.Warning,
-				messageFunction: () => { return localize('maxLengthWarning', 'String is longer than the maximum length of {0}.', schema.maxLength); }
+				getMessage: () => localize('maxLengthWarning', 'String is longer than the maximum length of {0}.', schema.maxLength)
 			});
 		}
 	
@@ -326,7 +326,7 @@ export class ASTNode {
 				validationResult.problems.push({
 					location: { start: this.start, end: this.end },
 					severity: ProblemSeverity.Warning,
-					messageFunction: () => { return schema.patternErrorMessage || schema.errorMessage || localize('patternWarning', 'String does not match the pattern of "{0}".', schema.pattern); }
+					getMessage: () => schema.patternErrorMessage || schema.errorMessage || localize('patternWarning', 'String does not match the pattern of "{0}".', schema.pattern)
 				});
 			}
 		}
@@ -438,7 +438,7 @@ export class ArrayASTNode extends ASTNode {
 					validationResult.problems.push({
 						location: { start: this.start, end: this.end },
 						severity: ProblemSeverity.Warning,
-						messageFunction: () => { return localize('additionalItemsWarning', 'Array has too many items according to schema. Expected {0} or fewer.', subSchemas.length); }
+						getMessage: () => localize('additionalItemsWarning', 'Array has too many items according to schema. Expected {0} or fewer.', subSchemas.length)
 					});
 				}
 			}
@@ -455,7 +455,7 @@ export class ArrayASTNode extends ASTNode {
 			validationResult.problems.push({
 				location: { start: this.start, end: this.end },
 				severity: ProblemSeverity.Warning,
-				messageFunction: () => { return localize('minItemsWarning', 'Array has too few items. Expected {0} or more.', schema.minItems); }
+				getMessage: () => localize('minItemsWarning', 'Array has too few items. Expected {0} or more.', schema.minItems)
 			});
 		}
 
@@ -463,7 +463,7 @@ export class ArrayASTNode extends ASTNode {
 			validationResult.problems.push({
 				location: { start: this.start, end: this.end },
 				severity: ProblemSeverity.Warning,
-				messageFunction: () => { return localize('maxItemsWarning', 'Array has too many items. Expected {0} or fewer.', schema.minItems); }
+				getMessage: () => localize('maxItemsWarning', 'Array has too many items. Expected {0} or fewer.', schema.maxItems)
 			});
 		}
 
@@ -478,7 +478,7 @@ export class ArrayASTNode extends ASTNode {
 				validationResult.problems.push({
 					location: { start: this.start, end: this.end },
 					severity: ProblemSeverity.Warning,
-					messageFunction: () => { return localize('uniqueItemsWarning', 'Array has duplicate items.'); }
+					getMessage: () => localize('uniqueItemsWarning', 'Array has duplicate items.')
 				});
 			}
 		}
@@ -529,7 +529,7 @@ export class NumberASTNode extends ASTNode {
 					validationResult.problems.push({
 						location: { start: this.start, end: this.end },
 						severity: ProblemSeverity.Warning,
-						messageFunction: () => { return localize('multipleOfWarning', 'Value is not divisible by {0}.', schema.multipleOf); }
+						getMessage: () => localize('multipleOfWarning', 'Value is not divisible by {0}.', schema.multipleOf)
 					});
 				}
 			}
@@ -539,14 +539,14 @@ export class NumberASTNode extends ASTNode {
 					validationResult.problems.push({
 						location: { start: this.start, end: this.end },
 						severity: ProblemSeverity.Warning,
-						messageFunction: () => { return localize('exclusiveMinimumWarning', 'Value is below the exclusive minimum of {0}.', schema.minimum); }
+						getMessage: () => localize('exclusiveMinimumWarning', 'Value is below the exclusive minimum of {0}.', schema.minimum)
 					});
 				}
 				if (!schema.exclusiveMinimum && val < schema.minimum) {
 					validationResult.problems.push({
 						location: { start: this.start, end: this.end },
 						severity: ProblemSeverity.Warning,
-						messageFunction: () => { return localize('minimumWarning', 'Value is below the minimum of {0}.', schema.minimum); }
+						getMessage: () => localize('minimumWarning', 'Value is below the minimum of {0}.', schema.minimum)
 					});
 				}
 			}
@@ -556,14 +556,14 @@ export class NumberASTNode extends ASTNode {
 					validationResult.problems.push({
 						location: { start: this.start, end: this.end },
 						severity: ProblemSeverity.Warning,
-						messageFunction: () => { return localize('exclusiveMaximumWarning', 'Value is above the exclusive maximum of {0}.', schema.maximum); }
+						getMessage: () => localize('exclusiveMaximumWarning', 'Value is above the exclusive maximum of {0}.', schema.maximum)
 					});
 				}
 				if (!schema.exclusiveMaximum && val > schema.maximum) {
 					validationResult.problems.push({
 						location: { start: this.start, end: this.end },
 						severity: ProblemSeverity.Warning,
-						messageFunction: () => { return localize('maximumWarning', 'Value is above the maximum of {0}.', schema.maximum); }
+						getMessage: () => localize('maximumWarning', 'Value is above the maximum of {0}.', schema.maximum)
 					});
 				}
 			}
@@ -800,7 +800,7 @@ export class ObjectASTNode extends ASTNode {
 					validationResult.problems.push({
 						location: location,
 						severity: ProblemSeverity.Warning,
-						messageFunction: () => { return localize('MissingRequiredPropWarning', 'Missing property "{0}".', propertyName); }
+						getMessage: () => localize('MissingRequiredPropWarning', 'Missing property "{0}".', propertyName)
 					});
 				}
 			});
@@ -868,7 +868,7 @@ export class ObjectASTNode extends ASTNode {
 						validationResult.problems.push({
 							location: {start: childProperty.key.start, end: childProperty.key.end},
 							severity: ProblemSeverity.Error,
-							messageFunction: () => { return localize('DuplicatePropError', 'Multiple properties found matching {0}', schemaPropertyName); }
+							getMessage: () => localize('DuplicatePropError', 'Multiple properties found matching {0}', schemaPropertyName)
 						})
 					}
 					else {
@@ -941,7 +941,7 @@ export class ObjectASTNode extends ASTNode {
 							validationResult.problems.push({
 								location: { start: propertyNode.key.start, end: propertyNode.key.end },
 								severity: ProblemSeverity.Warning,
-								messageFunction: () => { return schema.errorMessage || localize('DisallowedExtraPropWarning', 'Unexpected property {0}', propertyName); }
+								getMessage: () => schema.errorMessage || localize('DisallowedExtraPropWarning', 'Unexpected property {0}', propertyName)
 							});
 						}
 					}
@@ -954,7 +954,7 @@ export class ObjectASTNode extends ASTNode {
 				validationResult.problems.push({
 					location: { start: this.start, end: this.end },
 					severity: ProblemSeverity.Warning,
-					messageFunction: () => { return localize('MaxPropWarning', 'Object has more properties than limit of {0}.', schema.maxProperties); }
+					getMessage: () => localize('MaxPropWarning', 'Object has more properties than limit of {0}.', schema.maxProperties)
 				});
 			}
 		}
@@ -964,7 +964,7 @@ export class ObjectASTNode extends ASTNode {
 				validationResult.problems.push({
 					location: { start: this.start, end: this.end },
 					severity: ProblemSeverity.Warning,
-					messageFunction: () => { return localize('MinPropWarning', 'Object has fewer properties than the required number of {0}', schema.minProperties); }
+					getMessage: () => localize('MinPropWarning', 'Object has fewer properties than the required number of {0}', schema.minProperties)
 				});
 			}
 		}
@@ -979,7 +979,7 @@ export class ObjectASTNode extends ASTNode {
 								validationResult.problems.push({
 									location: { start: this.start, end: this.end },
 									severity: ProblemSeverity.Warning,
-									messageFunction: () => { return localize('RequiredDependentPropWarning', 'Object is missing property {0} required by property {1}.', requiredProp, key); }
+									getMessage: () => localize('RequiredDependentPropWarning', 'Object is missing property {0} required by property {1}.', requiredProp, key)
 								});
 							} else {
 								validationResult.propertiesValueMatches++;
@@ -1034,14 +1034,14 @@ export class ObjectASTNode extends ASTNode {
 						validationResult.problems.push({
 							location: { start: firstProperty.start, end: firstProperty.end },
 							severity: ProblemSeverity.Error,
-							messageFunction: () => { return localize('firstPropertyError', "The first property must be {0}", schema.firstProperty[0]); }
+							getMessage: () => localize('firstPropertyError', "The first property must be {0}", schema.firstProperty[0])
 						});
 					}
 					else {
 						validationResult.problems.push({
 							location: { start: firstProperty.start, end: firstProperty.end },
 							severity: ProblemSeverity.Error,
-							messageFunction: () => {
+							getMessage: () => {
 								const separator: string = localize('listSeparator', ", ");
 								return localize('firstPropertyErrorList', "The first property must be one of: {0}", schema.firstProperty.join(separator));
 							}
@@ -1136,7 +1136,7 @@ export class ValidationResult {
 			this.enumValues = this.enumValues.concat(validationResult.enumValues);
 			for (let error of this.problems) {
 				if (error.code === ErrorCode.EnumValueMismatch) {
-					error.messageFunction = () => { return localize('enumWarning', 'Value is not accepted. Valid values: {0}.', this.enumValues.map(v => JSON.stringify(v)).join(', ')); };
+					error.getMessage = () => localize('enumWarning', 'Value is not accepted. Valid values: {0}.', this.enumValues.map(v => JSON.stringify(v)).join(', '));
 				}
 			}
 		}

--- a/language-service/src/parser/jsonParser.ts
+++ b/language-service/src/parser/jsonParser.ts
@@ -33,7 +33,7 @@ export interface IProblem {
 	location: IRange;
 	severity: ProblemSeverity;
 	code?: ErrorCode;
-	message: string;
+	messageFunction: () => string;
 }
 
 export class ASTNode {
@@ -178,7 +178,7 @@ export class ASTNode {
 					validationResult.problems.push({
 						location: { start: this.start, end: this.end },
 						severity: ProblemSeverity.Warning,
-						message: schema.errorMessage || localize('typeArrayMismatchWarning', 'Incorrect type. Expected one of {0}.', (<string[]>schema.type).join(', '))
+						messageFunction: () => { return schema.errorMessage || localize('typeArrayMismatchWarning', 'Incorrect type. Expected one of {0}.', (<string[]>schema.type).join(', ')); }
 					});
 				}
 			}
@@ -190,7 +190,7 @@ export class ASTNode {
 					validationResult.problems.push({
 						location: { start: this.start, end: this.end },
 						severity: ProblemSeverity.Warning,
-						message: schema.errorMessage || localize('typeMismatchWarning', 'Incorrect type. Expected "{0}".', schema.type)
+						messageFunction: () => { return schema.errorMessage || localize('typeMismatchWarning', 'Incorrect type. Expected "{0}".', schema.type); }
 					});
 				}
 			}
@@ -208,7 +208,7 @@ export class ASTNode {
 				validationResult.problems.push({
 					location: { start: this.start, end: this.end },
 					severity: ProblemSeverity.Warning,
-					message: localize('notSchemaWarning', "Matches a schema that is not allowed.")
+					messageFunction: () => { return localize('notSchemaWarning', "Matches a schema that is not allowed."); }
 				});
 			}
 			subMatchingSchemas.schemas.forEach((ms) => {
@@ -243,7 +243,7 @@ export class ASTNode {
 				validationResult.problems.push({
 					location: { start: this.start, end: this.start + 1 },
 					severity: ProblemSeverity.Warning,
-					message: localize('oneOfWarning', "Matches multiple schemas when only one must validate.")
+					messageFunction: () => { return localize('oneOfWarning', "Matches multiple schemas when only one must validate."); }
 				});
 			}
 
@@ -286,7 +286,7 @@ export class ASTNode {
 					location: { start: this.start, end: this.end },
 					severity: ProblemSeverity.Warning,
 					code: ErrorCode.EnumValueMismatch,
-					message: schema.errorMessage || localize('enumWarning', 'Value is not accepted. Valid values: {0}.', schema.enum.map(v => JSON.stringify(v)).join(', '))
+					messageFunction: () => { return schema.errorMessage || localize('enumWarning', 'Value is not accepted. Valid values: {0}.', schema.enum.map(v => JSON.stringify(v)).join(', ')); }
 				});
 			}
 		}
@@ -295,7 +295,7 @@ export class ASTNode {
 			validationResult.problems.push({
 				location: { start: this.parent.start, end: this.parent.end },
 				severity: ProblemSeverity.Hint,
-				message: schema.deprecationMessage
+				messageFunction: () => { return schema.deprecationMessage; }
 			});
 		}
 
@@ -307,7 +307,7 @@ export class ASTNode {
 			validationResult.problems.push({
 				location: { start: this.start, end: this.end },
 				severity: ProblemSeverity.Warning,
-				message: localize('minLengthWarning', 'String is shorter than the minimum length of {0}.', schema.minLength)
+				messageFunction: () => { return localize('minLengthWarning', 'String is shorter than the minimum length of {0}.', schema.minLength); }
 			});
 		}
 	
@@ -315,7 +315,7 @@ export class ASTNode {
 			validationResult.problems.push({
 				location: { start: this.start, end: this.end },
 				severity: ProblemSeverity.Warning,
-				message: localize('maxLengthWarning', 'String is longer than the maximum length of {0}.', schema.maxLength)
+				messageFunction: () => { return localize('maxLengthWarning', 'String is longer than the maximum length of {0}.', schema.maxLength); }
 			});
 		}
 	
@@ -326,7 +326,7 @@ export class ASTNode {
 				validationResult.problems.push({
 					location: { start: this.start, end: this.end },
 					severity: ProblemSeverity.Warning,
-					message: schema.patternErrorMessage || schema.errorMessage || localize('patternWarning', 'String does not match the pattern of "{0}".', schema.pattern)
+					messageFunction: () => { return schema.patternErrorMessage || schema.errorMessage || localize('patternWarning', 'String does not match the pattern of "{0}".', schema.pattern); }
 				});
 			}
 		}
@@ -438,7 +438,7 @@ export class ArrayASTNode extends ASTNode {
 					validationResult.problems.push({
 						location: { start: this.start, end: this.end },
 						severity: ProblemSeverity.Warning,
-						message: localize('additionalItemsWarning', 'Array has too many items according to schema. Expected {0} or fewer.', subSchemas.length)
+						messageFunction: () => { return localize('additionalItemsWarning', 'Array has too many items according to schema. Expected {0} or fewer.', subSchemas.length); }
 					});
 				}
 			}
@@ -455,7 +455,7 @@ export class ArrayASTNode extends ASTNode {
 			validationResult.problems.push({
 				location: { start: this.start, end: this.end },
 				severity: ProblemSeverity.Warning,
-				message: localize('minItemsWarning', 'Array has too few items. Expected {0} or more.', schema.minItems)
+				messageFunction: () => { return localize('minItemsWarning', 'Array has too few items. Expected {0} or more.', schema.minItems); }
 			});
 		}
 
@@ -463,7 +463,7 @@ export class ArrayASTNode extends ASTNode {
 			validationResult.problems.push({
 				location: { start: this.start, end: this.end },
 				severity: ProblemSeverity.Warning,
-				message: localize('maxItemsWarning', 'Array has too many items. Expected {0} or fewer.', schema.minItems)
+				messageFunction: () => { return localize('maxItemsWarning', 'Array has too many items. Expected {0} or fewer.', schema.minItems); }
 			});
 		}
 
@@ -478,7 +478,7 @@ export class ArrayASTNode extends ASTNode {
 				validationResult.problems.push({
 					location: { start: this.start, end: this.end },
 					severity: ProblemSeverity.Warning,
-					message: localize('uniqueItemsWarning', 'Array has duplicate items.')
+					messageFunction: () => { return localize('uniqueItemsWarning', 'Array has duplicate items.'); }
 				});
 			}
 		}
@@ -529,7 +529,7 @@ export class NumberASTNode extends ASTNode {
 					validationResult.problems.push({
 						location: { start: this.start, end: this.end },
 						severity: ProblemSeverity.Warning,
-						message: localize('multipleOfWarning', 'Value is not divisible by {0}.', schema.multipleOf)
+						messageFunction: () => { return localize('multipleOfWarning', 'Value is not divisible by {0}.', schema.multipleOf); }
 					});
 				}
 			}
@@ -539,14 +539,14 @@ export class NumberASTNode extends ASTNode {
 					validationResult.problems.push({
 						location: { start: this.start, end: this.end },
 						severity: ProblemSeverity.Warning,
-						message: localize('exclusiveMinimumWarning', 'Value is below the exclusive minimum of {0}.', schema.minimum)
+						messageFunction: () => { return localize('exclusiveMinimumWarning', 'Value is below the exclusive minimum of {0}.', schema.minimum); }
 					});
 				}
 				if (!schema.exclusiveMinimum && val < schema.minimum) {
 					validationResult.problems.push({
 						location: { start: this.start, end: this.end },
 						severity: ProblemSeverity.Warning,
-						message: localize('minimumWarning', 'Value is below the minimum of {0}.', schema.minimum)
+						messageFunction: () => { return localize('minimumWarning', 'Value is below the minimum of {0}.', schema.minimum); }
 					});
 				}
 			}
@@ -556,14 +556,14 @@ export class NumberASTNode extends ASTNode {
 					validationResult.problems.push({
 						location: { start: this.start, end: this.end },
 						severity: ProblemSeverity.Warning,
-						message: localize('exclusiveMaximumWarning', 'Value is above the exclusive maximum of {0}.', schema.maximum)
+						messageFunction: () => { return localize('exclusiveMaximumWarning', 'Value is above the exclusive maximum of {0}.', schema.maximum); }
 					});
 				}
 				if (!schema.exclusiveMaximum && val > schema.maximum) {
 					validationResult.problems.push({
 						location: { start: this.start, end: this.end },
 						severity: ProblemSeverity.Warning,
-						message: localize('maximumWarning', 'Value is above the maximum of {0}.', schema.maximum)
+						messageFunction: () => { return localize('maximumWarning', 'Value is above the maximum of {0}.', schema.maximum); }
 					});
 				}
 			}
@@ -800,7 +800,7 @@ export class ObjectASTNode extends ASTNode {
 					validationResult.problems.push({
 						location: location,
 						severity: ProblemSeverity.Warning,
-						message: localize('MissingRequiredPropWarning', 'Missing property "{0}".', propertyName)
+						messageFunction: () => { return localize('MissingRequiredPropWarning', 'Missing property "{0}".', propertyName); }
 					});
 				}
 			});
@@ -868,7 +868,7 @@ export class ObjectASTNode extends ASTNode {
 						validationResult.problems.push({
 							location: {start: childProperty.key.start, end: childProperty.key.end},
 							severity: ProblemSeverity.Error,
-							message: localize('DuplicatePropError', 'Multiple properties found matching {0}', schemaPropertyName)
+							messageFunction: () => { return localize('DuplicatePropError', 'Multiple properties found matching {0}', schemaPropertyName); }
 						})
 					}
 					else {
@@ -941,7 +941,7 @@ export class ObjectASTNode extends ASTNode {
 							validationResult.problems.push({
 								location: { start: propertyNode.key.start, end: propertyNode.key.end },
 								severity: ProblemSeverity.Warning,
-								message: schema.errorMessage || localize('DisallowedExtraPropWarning', 'Unexpected property {0}', propertyName)
+								messageFunction: () => { return schema.errorMessage || localize('DisallowedExtraPropWarning', 'Unexpected property {0}', propertyName); }
 							});
 						}
 					}
@@ -954,7 +954,7 @@ export class ObjectASTNode extends ASTNode {
 				validationResult.problems.push({
 					location: { start: this.start, end: this.end },
 					severity: ProblemSeverity.Warning,
-					message: localize('MaxPropWarning', 'Object has more properties than limit of {0}.', schema.maxProperties)
+					messageFunction: () => { return localize('MaxPropWarning', 'Object has more properties than limit of {0}.', schema.maxProperties); }
 				});
 			}
 		}
@@ -964,7 +964,7 @@ export class ObjectASTNode extends ASTNode {
 				validationResult.problems.push({
 					location: { start: this.start, end: this.end },
 					severity: ProblemSeverity.Warning,
-					message: localize('MinPropWarning', 'Object has fewer properties than the required number of {0}', schema.minProperties)
+					messageFunction: () => { return localize('MinPropWarning', 'Object has fewer properties than the required number of {0}', schema.minProperties); }
 				});
 			}
 		}
@@ -979,7 +979,7 @@ export class ObjectASTNode extends ASTNode {
 								validationResult.problems.push({
 									location: { start: this.start, end: this.end },
 									severity: ProblemSeverity.Warning,
-									message: localize('RequiredDependentPropWarning', 'Object is missing property {0} required by property {1}.', requiredProp, key)
+									messageFunction: () => { return localize('RequiredDependentPropWarning', 'Object is missing property {0} required by property {1}.', requiredProp, key); }
 								});
 							} else {
 								validationResult.propertiesValueMatches++;
@@ -1034,7 +1034,7 @@ export class ObjectASTNode extends ASTNode {
 						validationResult.problems.push({
 							location: { start: firstProperty.start, end: firstProperty.end },
 							severity: ProblemSeverity.Error,
-							message: localize('firstPropertyError', "The first property must be {0}", schema.firstProperty[0])
+							messageFunction: () => { return localize('firstPropertyError', "The first property must be {0}", schema.firstProperty[0]); }
 						});
 					}
 					else {
@@ -1042,7 +1042,7 @@ export class ObjectASTNode extends ASTNode {
 						validationResult.problems.push({
 							location: { start: firstProperty.start, end: firstProperty.end },
 							severity: ProblemSeverity.Error,
-							message: localize('firstPropertyErrorList', "The first property must be one of: {0}", schema.firstProperty.join(separator))
+							messageFunction: () => { return localize('firstPropertyErrorList', "The first property must be one of: {0}", schema.firstProperty.join(separator)); }
 						});
 					}
 				}
@@ -1104,8 +1104,6 @@ export class ValidationResult {
 	public primaryValueMatches: number;
 	public enumValueMatch: boolean;
 	public enumValues: any[];
-	public warnings;
-	public errors;
 
 	constructor() {
 		this.problems = [];
@@ -1115,8 +1113,6 @@ export class ValidationResult {
 		this.primaryValueMatches = 0;
 		this.enumValueMatch = false;
 		this.enumValues = null;
-		this.warnings = [];
-		this.errors = [];
 	}
 
 	public hasProblems(): boolean {
@@ -1138,7 +1134,7 @@ export class ValidationResult {
 			this.enumValues = this.enumValues.concat(validationResult.enumValues);
 			for (let error of this.problems) {
 				if (error.code === ErrorCode.EnumValueMismatch) {
-					error.message = localize('enumWarning', 'Value is not accepted. Valid values: {0}.', this.enumValues.map(v => JSON.stringify(v)).join(', '));
+					error.messageFunction = () => { return localize('enumWarning', 'Value is not accepted. Valid values: {0}.', this.enumValues.map(v => JSON.stringify(v)).join(', ')); };
 				}
 			}
 		}

--- a/language-service/src/parser/jsonParser.ts
+++ b/language-service/src/parser/jsonParser.ts
@@ -1038,11 +1038,13 @@ export class ObjectASTNode extends ASTNode {
 						});
 					}
 					else {
-						const separator: string = localize('listSeparator', ", ");
 						validationResult.problems.push({
 							location: { start: firstProperty.start, end: firstProperty.end },
 							severity: ProblemSeverity.Error,
-							messageFunction: () => { return localize('firstPropertyErrorList', "The first property must be one of: {0}", schema.firstProperty.join(separator)); }
+							messageFunction: () => {
+								const separator: string = localize('listSeparator', ", ");
+								return localize('firstPropertyErrorList', "The first property must be one of: {0}", schema.firstProperty.join(separator));
+							}
 						});
 					}
 				}

--- a/language-service/src/parser/yamlParser.ts
+++ b/language-service/src/parser/yamlParser.ts
@@ -16,7 +16,7 @@ import { Schema, Type } from 'js-yaml';
 import { getLineStartPositions, getPosition, ILineColumn } from '../utils/documentPositionCalculator'
 
 export interface YAMLError {
-	message: string;
+	messageFunction: () => string;
 	start: number;
 	end: number;
 }
@@ -195,7 +195,7 @@ function recursivelyBuildAst(parent: ASTNode, node: Yaml.YAMLNode): ASTNode {
 }
 
 function convertError(e: Yaml.YAMLException): YAMLError {
-	return { message: e.reason, start: e.mark.position, end: e.mark.position + e.mark.column };
+	return { messageFunction: () => { return e.reason }, start: e.mark.position, end: e.mark.position + e.mark.column };
 }
 
 function createJSONDocument(yamlNode: Yaml.YAMLNode, startPositions: number[], text: string): SingleYAMLDocument {
@@ -204,7 +204,7 @@ function createJSONDocument(yamlNode: Yaml.YAMLNode, startPositions: number[], t
 
 	if (!_doc.root) {
 		// TODO: When this is true, consider not pushing the other errors.
-		_doc.errors.push({ message: localize('Invalid symbol', 'Expected a YAML object, array or literal'), start: yamlNode.startPosition, end: yamlNode.endPosition } );
+		_doc.errors.push({ messageFunction: () => { return localize('Invalid symbol', 'Expected a YAML object, array or literal'); }, start: yamlNode.startPosition, end: yamlNode.endPosition } );
 	}
 
 	const duplicateKeyReason: string = 'duplicate key';

--- a/language-service/src/parser/yamlParser.ts
+++ b/language-service/src/parser/yamlParser.ts
@@ -16,7 +16,7 @@ import { Schema, Type } from 'js-yaml';
 import { getLineStartPositions, getPosition, ILineColumn } from '../utils/documentPositionCalculator'
 
 export interface YAMLError {
-	messageFunction: () => string;
+	getMessage: () => string;
 	start: number;
 	end: number;
 }
@@ -195,7 +195,7 @@ function recursivelyBuildAst(parent: ASTNode, node: Yaml.YAMLNode): ASTNode {
 }
 
 function convertError(e: Yaml.YAMLException): YAMLError {
-	return { messageFunction: () => { return e.reason }, start: e.mark.position, end: e.mark.position + e.mark.column };
+	return { getMessage: () => e.reason, start: e.mark.position, end: e.mark.position + e.mark.column };
 }
 
 function createJSONDocument(yamlNode: Yaml.YAMLNode, startPositions: number[], text: string): SingleYAMLDocument {
@@ -204,7 +204,7 @@ function createJSONDocument(yamlNode: Yaml.YAMLNode, startPositions: number[], t
 
 	if (!_doc.root) {
 		// TODO: When this is true, consider not pushing the other errors.
-		_doc.errors.push({ messageFunction: () => { return localize('Invalid symbol', 'Expected a YAML object, array or literal'); }, start: yamlNode.startPosition, end: yamlNode.endPosition } );
+		_doc.errors.push({ getMessage: () => localize('Invalid symbol', 'Expected a YAML object, array or literal'), start: yamlNode.startPosition, end: yamlNode.endPosition } );
 	}
 
 	const duplicateKeyReason: string = 'duplicate key';

--- a/language-service/src/services/yamlValidation.ts
+++ b/language-service/src/services/yamlValidation.ts
@@ -81,7 +81,7 @@ export class YAMLValidation {
 						start: textDocument.positionAt(err.start),
 						end: textDocument.positionAt(err.end)
 					},
-					message: err.message
+					message: err.messageFunction()
 				});
 			});
 
@@ -92,7 +92,7 @@ export class YAMLValidation {
 						start: textDocument.positionAt(warn.start),
 						end: textDocument.positionAt(warn.end)
 					},
-					message: warn.message
+					message: warn.messageFunction()
 				});
 			});
 
@@ -100,7 +100,8 @@ export class YAMLValidation {
 				var added: {[key:string]: boolean} = {};
 				const problems: IProblem[] = jsonDocument.getValidationProblems(schema.schema);
 				problems.forEach(function (problem: IProblem, index: number) {
-					const signature: string = '' + problem.location.start + ' ' + problem.location.end + ' ' + problem.message;
+					const message: string = problem.messageFunction();
+					const signature: string = '' + problem.location.start + ' ' + problem.location.end + ' ' + message
 					if (!added[signature]) {
 						added[signature] = true;
 						diagnostics.push({
@@ -109,7 +110,7 @@ export class YAMLValidation {
 								start: textDocument.positionAt(problem.location.start),
 								end: textDocument.positionAt(problem.location.end)
 							},
-							message: problem.message
+							message: message
 						})
 					}
 				});

--- a/language-service/src/services/yamlValidation.ts
+++ b/language-service/src/services/yamlValidation.ts
@@ -81,7 +81,7 @@ export class YAMLValidation {
 						start: textDocument.positionAt(err.start),
 						end: textDocument.positionAt(err.end)
 					},
-					message: err.messageFunction()
+					message: err.getMessage()
 				});
 			});
 
@@ -92,7 +92,7 @@ export class YAMLValidation {
 						start: textDocument.positionAt(warn.start),
 						end: textDocument.positionAt(warn.end)
 					},
-					message: warn.messageFunction()
+					message: warn.getMessage()
 				});
 			});
 
@@ -100,7 +100,7 @@ export class YAMLValidation {
 				var added: {[key:string]: boolean} = {};
 				const problems: IProblem[] = jsonDocument.getValidationProblems(schema.schema);
 				problems.forEach(function (problem: IProblem, index: number) {
-					const message: string = problem.messageFunction();
+					const message: string = problem.getMessage();
 					const signature: string = '' + problem.location.start + ' ' + problem.location.end + ' ' + message
 					if (!added[signature]) {
 						added[signature] = true;


### PR DESCRIPTION
delay calling `localize` when validating YAML files so that it is only called for errors that will be presented to the user.

Before this change, `localize` was called whenever an error was detected while attempting to match a schema section to a YAML section, which is most of the time.