### PR TITLE
Use firstProperty to reduce possible matches when evaluating schema

### DIFF
--- a/language-service/CHANGELOG.md
+++ b/language-service/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+#### 0.5.3
+Improve performance
+
 #### 0.5.2
 Fix a regression with YAML structure errors [#PR-49](https://github.com/Microsoft/azure-pipelines-language-server/pull/49)
 Improve performance [#PR-50](https://github.com/Microsoft/azure-pipelines-language-server/pull/50)

--- a/language-service/CHANGELOG.md
+++ b/language-service/CHANGELOG.md
@@ -1,6 +1,6 @@
 
 #### 0.5.3
-Improve performance
+Improve performance [#PR-51](https://github.com/Microsoft/azure-pipelines-language-server/pull/51)
 
 #### 0.5.2
 Fix a regression with YAML structure errors [#PR-49](https://github.com/Microsoft/azure-pipelines-language-server/pull/49)

--- a/language-service/package-lock.json
+++ b/language-service/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-language-service",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/language-service/package.json
+++ b/language-service/package.json
@@ -1,7 +1,7 @@
 {
   "name": "azure-pipelines-language-service",
   "description": "Azure Pipelines language service",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "author": "Microsoft",
   "license": "MIT",
   "main": "./lib/src/index.js",


### PR DESCRIPTION
In my tests, this reduced `validate` time by over 50%