### PR TITLE
Improve schema matching by considering the tree depth of errors

### DIFF
--- a/language-service/CHANGELOG.md
+++ b/language-service/CHANGELOG.md
@@ -1,6 +1,7 @@
 
 #### 0.5.3
 Improve performance [#PR-51](https://github.com/Microsoft/azure-pipelines-language-server/pull/51)
+Improve error messages and suggestions
 
 #### 0.5.2
 Fix a regression with YAML structure errors [#PR-49](https://github.com/Microsoft/azure-pipelines-language-server/pull/49)

--- a/language-service/CHANGELOG.md
+++ b/language-service/CHANGELOG.md
@@ -1,7 +1,7 @@
 
 #### 0.5.3
 Improve performance [#PR-51](https://github.com/Microsoft/azure-pipelines-language-server/pull/51)
-Improve error messages and suggestions
+Improve error messages and suggestions [#PR-52](https://github.com/Microsoft/azure-pipelines-language-server/pull/52)
 
 #### 0.5.2
 Fix a regression with YAML structure errors [#PR-49](https://github.com/Microsoft/azure-pipelines-language-server/pull/49)

--- a/language-service/src/parser/jsonParser.ts
+++ b/language-service/src/parser/jsonParser.ts
@@ -1168,7 +1168,7 @@ class NoOpSchemaCollector implements ISchemaCollector {
 
 export class ValidationResult {
 	public problems: IProblem[];
-	public problemDepths: number[];
+	public problemDepths: number[];  //count of problems found at each level of the parse tree.  problemDepths[0] is the root, problemDepths[1] is one level down, etc.
 
 	public firstPropertyProblems: number;
 	public propertiesMatches: number;
@@ -1200,11 +1200,15 @@ export class ValidationResult {
 	public mergeSubResult(validationResult: ValidationResult): void {
 		this.problems = this.problems.concat(validationResult.problems);
 
+		//overlay the problem count array one level down
+
+		//first make sure the array is long enough
 		const subDepth: number = validationResult.problemDepths.length;
 		while (this.problemDepths.length <= subDepth) {
 			this.problemDepths.push(0);
 		}
 
+		//then add the problem counts shifted lower in the parse tree
 		validationResult.problemDepths.forEach((problemCount: number, depth: number) => {
 			this.problemDepths[depth + 1] += problemCount;
 		});


### PR DESCRIPTION
Known issue: when getting suggestions for a step, the description for "task" is not the top-level task description but a specific task