### PR TITLE
detect when badly formed YAML causes the multi-document error

### DIFF
--- a/language-service/CHANGELOG.md
+++ b/language-service/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+#### 0.5.5
+Better handling of YAML structure errors
+
 #### 0.5.4
 Change schema service to use a schema object instead of a JSON string [#PR-53](https://github.com/Microsoft/azure-pipelines-language-server/pull/53)
 

--- a/language-service/package-lock.json
+++ b/language-service/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-language-service",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/language-service/package.json
+++ b/language-service/package.json
@@ -1,7 +1,7 @@
 {
   "name": "azure-pipelines-language-service",
   "description": "Azure Pipelines language service",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "author": "Microsoft",
   "license": "MIT",
   "main": "./lib/src/index.js",


### PR DESCRIPTION
detect when badly formed YAML causes the multi-document error and then give an error on an individual line instead of flagging the entire file.

See: https://github.com/Microsoft/azure-pipelines-vscode/issues/219