### PR TITLE
Remove consideration of firstProperty schema element when generating errors

### DIFF
--- a/language-service/CHANGELOG.md
+++ b/language-service/CHANGELOG.md
@@ -1,6 +1,7 @@
 
 #### 0.5.7
 Allow boolean values to validate against string schema [#PR-62](https://github.com/microsoft/azure-pipelines-language-server/pull/62)
+Remove consideration of firstProperty schema element when generating errors [#PR-63](https://github.com/microsoft/azure-pipelines-language-server/pull/63)
 
 #### 0.5.6
 Cache schemas when using a custom schema provider to improve performance [#PR-60](https://github.com/Microsoft/azure-pipelines-language-server/pull/60)


### PR DESCRIPTION
When generating errors, we were using firstProperty tags to improve the message in situations such as [this](https://github.com/microsoft/azure-pipelines-vscode/issues/156).  However when we [started using firstProperty to direct the subSchema evaluation](https://github.com/microsoft/azure-pipelines-language-server/pull/51) this became unnecessary and [counterproductive](https://github.com/microsoft/azure-pipelines-vscode/issues/197) so this PR removes firstProperty consideration when there are errors.