### PR TITLE
Clear schema cache on schema change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,7 @@
 _bundles/
 .nyc_output
-.vscode
 *.tgz
 lib/
 node_modules/
-npm-debug.log
 npm-debug.log
 out/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,10 @@
             "request": "attach",
             "port": 6009,
             "sourceMaps": true,
-            "outFiles": [ "${workspaceRoot}/out/server/**/*.ts" ],
+            "outFiles": [
+                "${workspaceFolder}/language-server/out/src/**/*.js",
+                "${workspaceFolder}/language-service/lib/src/**/*.js",
+            ],
             "protocol": "inspector",
             "trace": true
         },
@@ -35,7 +38,7 @@
             "request": "launch",
             "name": "Launch Server Tests",
             "cwd": "${workspaceFolder}/language-server",
-            "program": "${workspaceRoot}/language-server/node_modules/mocha/bin/_mocha",
+            "program": "${workspaceFolder}/language-server/node_modules/mocha/bin/_mocha",
             "args": [
                 "-u",
                 "tdd",

--- a/language-service/src/services/jsonSchemaService.ts
+++ b/language-service/src/services/jsonSchemaService.ts
@@ -336,6 +336,7 @@ export class JSONSchemaService implements IJSONSchemaService {
 		this.filePatternAssociations = [];
 		this.filePatternAssociationById = {};
 		this.registeredSchemasIds = {};
+		this.schemaCache = {};
 
 		for (let id in this.contributionSchemas) {
 			this.schemasById[id] = this.contributionSchemas[id];

--- a/language-service/src/services/yamlValidation.ts
+++ b/language-service/src/services/yamlValidation.ts
@@ -16,7 +16,7 @@ import * as nls from 'vscode-nls';
 const localize = nls.loadMessageBundle();
 
 export class YAMLValidation {
-	
+
 	private jsonSchemaService: JSONSchemaService;
 	private promise: PromiseConstructor;
 	private validationEnabled: boolean;
@@ -27,12 +27,12 @@ export class YAMLValidation {
 		this.validationEnabled = true;
 	}
 
-	public configure(shouldValidate: LanguageSettings): void {
-		if(shouldValidate){
-			this.validationEnabled = shouldValidate.validate;
+	public configure(settings: LanguageSettings): void {
+		if (settings) {
+			this.validationEnabled = settings.validate;
 		}
 	}
-	
+
 	public doValidation(textDocument: TextDocument, yamlDocument: YAMLDocument): Thenable<Diagnostic[]> {
 
 		if(!this.validationEnabled){
@@ -53,7 +53,7 @@ export class YAMLValidation {
 					if (docError.getMessage().includes("end of the stream or a document separator is expected")) {
 						const docErrorPosition : Position = textDocument.positionAt(docError.start);
 						const errorLine: number = (docErrorPosition.line > 0) ? docErrorPosition.line - 1 : docErrorPosition.line;
-						
+
 						return this.promise.resolve([{
 							severity: DiagnosticSeverity.Error,
 							range: {
@@ -92,7 +92,7 @@ export class YAMLValidation {
 			 if (problemSeverity == ProblemSeverity.Warning) {
 				 return DiagnosticSeverity.Warning;
 			 }
-	
+
 			 return DiagnosticSeverity.Hint;
 		};
 

--- a/language-service/src/yamlLanguageService.ts
+++ b/language-service/src/yamlLanguageService.ts
@@ -128,8 +128,8 @@ export function getLanguageService(
       configure: (settings) => {
         schemaService.clearExternalSchemas();
         if (settings.schemas) {
-          settings.schemas.forEach(settings => {
-            schemaService.registerExternalSchema(settings.uri, settings.fileMatch, settings.schema);
+          settings.schemas.forEach(schema => {
+            schemaService.registerExternalSchema(schema.uri, schema.fileMatch, schema.schema);
           });
         }
         yamlValidation.configure(settings);


### PR DESCRIPTION
The real one-liner change is in jsonSchemaService.ts; the rest is misc cleanup.

This fixes the schema not automatically refreshing when providing a new custom schema, as we would continue to short-circuit with the old cached schema.

Will allow the following lines in the extension to be removed:
https://github.com/microsoft/azure-pipelines-vscode/blob/e0139d040f7746b0c6a241ca4119fe43c3d85955/src/extension.ts#L97-L99