### PR TITLE
Better debugging story

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,7 @@
 _bundles/
 .nyc_output
-.vscode
 *.tgz
 lib/
 node_modules/
-npm-debug.log
 npm-debug.log
 out/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,10 +7,10 @@
             "type": "node",
             "request": "attach",
             "port": 6009,
-            "sourceMaps": true,
-            "outFiles": [ "${workspaceRoot}/out/server/**/*.ts" ],
-            "protocol": "inspector",
-            "trace": true
+            "outFiles": [
+                "${workspaceFolder}/language-server/out/**/*.ts",
+                "${workspaceFolder}/language-service/lib/**/*.ts"
+            ],
         },
         {
             "type": "node",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -35,7 +35,7 @@
             "request": "launch",
             "name": "Launch Server Tests",
             "cwd": "${workspaceFolder}/language-server",
-            "program": "${workspaceRoot}/language-server/node_modules/mocha/bin/_mocha",
+            "program": "${workspaceFolder}/language-server/node_modules/mocha/bin/_mocha",
             "args": [
                 "-u",
                 "tdd",

--- a/README.md
+++ b/README.md
@@ -31,22 +31,17 @@ This repo consists of 2 separate projects/packages:
 2. * [azure-pipelines-language-server](https://github.com/Microsoft/azure-pipelines-language-server/tree/master/language-server) - language server implementation that dependes on azure-pipelines-language-service
 
 In order to tighten the dev loop you can utilize `npm link` that will sync changes to service package without re-installing.
- 
- 1. First install dependencies for both service and server:
+
+1. First, install dependencies in the language service and start watching for changes:
     * `cd language-service`
     * `npm install`
-    * `npm run build`
+    * `npm run watch`
+2. Next, link the language service to the language server and start watching for changes:
     * `cd ../language-server`
     * `npm install`
-    * `npm run build` 
-2. Link languageservice/out/src to the global folder and connect it to the language-server's node_modules
-    * `cd ../language-service/out/src`
-    * `npm link`
-    * `npm ls -g` - to check it is added
-    * `cd ../language-server`
-    * `npm link azure-pipelines-language-service`
-3. Now you can make changes to the service compile and your changes will be awailable in the server
-    * Run `npm run watch` to auto detect changes and compile
+    * `npm link ../azure-pipelines-language-service`
+    * `npm run watch`
+3. Now, any changes you make in the service will automatically be reflected in the server
 
 ### Connecting to the language server via stdio
 There's an option to connect to the language server via [stdio](https://github.com/redhat-developer/yaml-language-server/blob/681985b5a059c2cb55c8171235b07e1651b6c546/src/server.ts#L46-L51) to help with intergrating the language server into different clients.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ In order to tighten the dev loop you can utilize `npm link` that will sync chang
 2. Next, link the language service to the language server and start watching for changes:
     * `cd ../language-server`
     * `npm install`
-    * `npm link ../azure-pipelines-language-service`
+    * `npm link ../language-service`
     * `npm run watch`
 3. Now, any changes you make in the service will automatically be reflected in the server
 

--- a/language-server/package-lock.json
+++ b/language-server/package-lock.json
@@ -627,12 +627,6 @@
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
       "dev": true
     },
-    "es6-object-assign": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
-      "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=",
-      "dev": true
-    },
     "es6-promise": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
@@ -909,12 +903,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
-    },
-    "interpret": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
-      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
       "dev": true
     },
     "is-buffer": {
@@ -1502,15 +1490,6 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
-    "rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dev": true,
-      "requires": {
-        "resolve": "^1.1.6"
-      }
-    },
     "release-zalgo": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
@@ -1648,28 +1627,6 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
-    },
-    "shelljs": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.2.tgz",
-      "integrity": "sha512-pRXeNrCA2Wd9itwhvLp5LZQvPJ0wU6bcjaTMywHHGX5XWhVN2nzSu7WV0q+oUY7mGK3mgSkDDzP3MgjqdyIgbQ==",
-      "dev": true,
-      "requires": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
-      }
-    },
-    "shx": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.2.tgz",
-      "integrity": "sha512-aS0mWtW3T2sHAenrSrip2XGv39O9dXIFUqxAEWHEOS1ePtGIBavdPJY1kE2IHl14V/4iCbUiNDPGdyYTtmhSoA==",
-      "dev": true,
-      "requires": {
-        "es6-object-assign": "^1.0.3",
-        "minimist": "^1.2.0",
-        "shelljs": "^0.8.1"
-      }
     },
     "signal-exit": {
       "version": "3.0.2",

--- a/language-server/package.json
+++ b/language-server/package.json
@@ -45,14 +45,12 @@
     "mocha-junit-reporter": "1.18.0",
     "mocha-lcov-reporter": "1.3.0",
     "nyc": "^15.0.0",
-    "shx": "0.3.2",
     "source-map-support": "0.5.5",
     "ts-node": "7.0.1",
     "typescript": "2.7.2"
   },
   "scripts": {
-    "build": "npm run compile && npm run preppackage && cd out/src && shx rm -f *.tgz && npm pack",
-    "preppackage": "shx cp package.json out/src && shx cp CHANGELOG.md out/src && shx cp LICENSE out/src && shx cp README.md out/src",
+    "build": "npm run compile && npm pack",
     "compile": "tsc -p .",
     "watch": "tsc -watch -p .",
     "test": "npm run compile && mocha --require ts-node/register --ui tdd ./test/*.test.ts",

--- a/language-server/tsconfig.json
+++ b/language-server/tsconfig.json
@@ -8,8 +8,7 @@
 		"lib" : [ "es2016" ],
 		"outDir": "./out"
 	},
-	"exclude": [
-		"node_modules",
-		"out"
+	"include": [
+		"src"
 	]
 }

--- a/language-service/package.json
+++ b/language-service/package.json
@@ -4,8 +4,8 @@
   "version": "0.5.10",
   "author": "Microsoft",
   "license": "MIT",
-  "main": "./lib/src/index.js",
-  "typings": "./lib/src/index",
+  "main": "./lib/index.js",
+  "typings": "./lib/index",
   "contributors": [
     {
       "name": "Stephen Franceschelli",

--- a/language-service/tsconfig.json
+++ b/language-service/tsconfig.json
@@ -10,8 +10,7 @@
 		"outDir": "./lib",
 		"noUnusedLocals": true
 	},
-	"exclude": [
-		"node_modules",
-		"lib"
+	"include": [
+		"src"
 	]
 }


### PR DESCRIPTION
- Only transpile the src folders and update the package.jsons to match
- Correct the paths that VS Code uses to look for source maps (and add language-service to the list)
- Touch up the README
- Remove .vscode from .gitignore

This does change the output structure of the npm packages. For the server, `server.ts` is now located in its own `out` subdirectory. For the service, all source files are now located under `lib`, rather than `lib/src`.