### PR TITLE
Enable webpacking of the language server

### DIFF
--- a/language-server/package-lock.json
+++ b/language-server/package-lock.json
@@ -229,15 +229,15 @@
       "dev": true
     },
     "@types/node": {
-      "version": "9.6.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.6.tgz",
-      "integrity": "sha512-SJe0g5cZeGNDP5sD8mIX3scb+eq8LQQZ60FXiKZHipYSeEFZ5EKml+NNMiO76F74TY4PoMWlNxF/YRY40FOvZQ==",
+      "version": "14.14.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.25.tgz",
+      "integrity": "sha512-EPpXLOVqDvisVxtlbvzfyqSsFeQxltFbluZNRndIb8tr9KiBnYNLzrc1N3pyKUCww2RNrfHDViqDWWE1LCJQtQ==",
       "dev": true
     },
     "agent-base": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
-      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
       "requires": {
         "es6-promisify": "^5.0.0"
       }
@@ -342,9 +342,9 @@
       "dev": true
     },
     "azure-pipelines-language-service": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-language-service/-/azure-pipelines-language-service-0.5.10.tgz",
-      "integrity": "sha512-d5wD9VLIZWTcSfooQWZJ3qhhNU88Eo++2llUaagOU+9R+o6Z1S2xBzcIjmhOD1w26V2HDqR+xGfuthtQrfHLsQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-language-service/-/azure-pipelines-language-service-0.6.0.tgz",
+      "integrity": "sha512-pRoxYr7+lyF+f+YQB+9H4HkqgR7lkqwt/iJaA8SUnBHhHbrLN7smN2aMms8LkMvhLcovFmwYTnBbEQelxDQoEg==",
       "requires": {
         "js-yaml": "3.13.1",
         "jsonc-parser": "2.0.2",
@@ -353,6 +353,23 @@
         "vscode-nls": "3.2.2",
         "vscode-uri": "1.0.3",
         "yaml-ast-parser": "0.0.40"
+      },
+      "dependencies": {
+        "vscode-languageserver-types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.6.1.tgz",
+          "integrity": "sha512-Npi3i8gUWcx5h8z5idNqPKBLJmZothXK2FSG4csEmxAR7avb8W6l9Ny+VW9yCUB3bOdD7iXfah8IO0AS1jwQmQ=="
+        },
+        "vscode-nls": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-3.2.2.tgz",
+          "integrity": "sha512-/Ur1+tgazwd51+ncRyoy0UIu4dvMdVXS9XMUULQlZIBoNGEwOhwEx9x+hHWoUjldMrOQ32t2CGKo0u6D4R6/hg=="
+        },
+        "vscode-uri": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.3.tgz",
+          "integrity": "sha1-Yxvb9xbcyrDmUpGo3CXCMjIIWlI="
+        }
       }
     },
     "balanced-match": {
@@ -628,9 +645,9 @@
       "dev": true
     },
     "es6-promise": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
-      "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "es6-promisify": {
       "version": "5.0.0",
@@ -865,16 +882,6 @@
       "requires": {
         "agent-base": "^4.3.0",
         "debug": "^3.1.0"
-      },
-      "dependencies": {
-        "agent-base": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-          "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
-          "requires": {
-            "es6-promisify": "^5.0.0"
-          }
-        }
       }
     },
     "imurmurhash": {
@@ -1528,13 +1535,20 @@
       }
     },
     "request-light": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.2.3.tgz",
-      "integrity": "sha512-KUQTybUtB/WZl7wQGAKenEJkuUX1/DyYX6PJpNEaBVyxE4v6U4Q5P65cmjdKglzcNTGIPZG857JMEAiMWVsoIw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.4.0.tgz",
+      "integrity": "sha512-fimzjIVw506FBZLspTAXHdpvgvQebyjpNyLRd0e6drPPRq7gcrROeGWRyF81wLqFg5ijPgnOQbmfck5wdTqpSA==",
       "requires": {
         "http-proxy-agent": "^2.1.0",
-        "https-proxy-agent": "^2.2.1",
-        "vscode-nls": "^3.2.2"
+        "https-proxy-agent": "^2.2.4",
+        "vscode-nls": "^4.1.2"
+      },
+      "dependencies": {
+        "vscode-nls": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-4.1.2.tgz",
+          "integrity": "sha512-7bOHxPsfyuCqmP+hZXscLhiHwe7CSuFE4hyhbs22xPIhQ4jv99FcR4eBzfYYVLP356HNFpdvz63FFb/xw6T4Iw=="
+        }
       }
     },
     "require-directory": {
@@ -1846,9 +1860,9 @@
       }
     },
     "typescript": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
-      "integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
       "dev": true
     },
     "uuid": {
@@ -1877,52 +1891,61 @@
         "vscode-languageserver-types": "^3.6.1",
         "vscode-nls": "^3.2.1",
         "vscode-uri": "^1.0.3"
-      }
-    },
-    "vscode-jsonrpc": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-3.6.1.tgz",
-      "integrity": "sha512-+Eb+Dxf2kC2h079msx61hkblxAKE0S2j78+8QpnigLAO2aIIjkCwTIH34etBrU8E8VItRinec7YEwULx9at5bQ=="
-    },
-    "vscode-languageserver": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-4.1.2.tgz",
-      "integrity": "sha512-3iej2tuMaI9yirPXF7/fVyIvBhSzbwZ3EWFRb8bP6lc3tGv9SJHDaJLNyQMgo9J8CNpXil6dWarpJvGSA60v/w==",
-      "requires": {
-        "vscode-languageserver-protocol": "^3.7.0",
-        "vscode-uri": "^1.0.1"
-      }
-    },
-    "vscode-languageserver-protocol": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.7.1.tgz",
-      "integrity": "sha512-AKX9XQ49m/lpiDLZJBypFNc5eAXNlSecunYU5m4o5WIwGgW86TWnXVdziuFm47W2SdigDa/jVbxLPSNUeut9fQ==",
-      "requires": {
-        "vscode-jsonrpc": "^3.6.0",
-        "vscode-languageserver-types": "^3.7.0"
       },
       "dependencies": {
-        "vscode-languageserver-types": {
-          "version": "3.7.1",
-          "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.7.1.tgz",
-          "integrity": "sha512-ftGfU79AnnI3OHCG7kzCCN47jNI7BjECPAH2yhddtYTiQk0bnFbuFeQKvpXQcyNI3GsKEx5b6kSiBYshTiep6w=="
+        "vscode-nls": {
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-3.2.5.tgz",
+          "integrity": "sha512-ITtoh3V4AkWXMmp3TB97vsMaHRgHhsSFPsUdzlueSL+dRZbSNTZeOmdQv60kjCV306ghPxhDeoNUEm3+EZMuyw=="
+        },
+        "vscode-uri": {
+          "version": "1.0.8",
+          "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.8.tgz",
+          "integrity": "sha512-obtSWTlbJ+a+TFRYGaUumtVwb+InIUVI0Lu0VBUAPmj2cU5JutEXg3xUE0c2J5Tcy7h2DEKVJBFi+Y9ZSFzzPQ=="
         }
       }
     },
+    "vscode-jsonrpc": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
+      "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg=="
+    },
+    "vscode-languageserver": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-7.0.0.tgz",
+      "integrity": "sha512-60HTx5ID+fLRcgdHfmz0LDZAXYEV68fzwG0JWwEPBode9NuMYTIxuYXPg4ngO8i8+Ou0lM7y6GzaYWbiDL0drw==",
+      "requires": {
+        "vscode-languageserver-protocol": "3.16.0"
+      }
+    },
+    "vscode-languageserver-protocol": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
+      "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
+      "requires": {
+        "vscode-jsonrpc": "6.0.0",
+        "vscode-languageserver-types": "3.16.0"
+      }
+    },
+    "vscode-languageserver-textdocument": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.1.tgz",
+      "integrity": "sha512-UIcJDjX7IFkck7cSkNNyzIz5FyvpQfY7sdzVy+wkKN/BLaD4DQ0ppXQrKePomCxTS7RrolK1I0pey0bG9eh8dA=="
+    },
     "vscode-languageserver-types": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.6.1.tgz",
-      "integrity": "sha512-Npi3i8gUWcx5h8z5idNqPKBLJmZothXK2FSG4csEmxAR7avb8W6l9Ny+VW9yCUB3bOdD7iXfah8IO0AS1jwQmQ=="
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
+      "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
     },
     "vscode-nls": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-3.2.2.tgz",
-      "integrity": "sha512-/Ur1+tgazwd51+ncRyoy0UIu4dvMdVXS9XMUULQlZIBoNGEwOhwEx9x+hHWoUjldMrOQ32t2CGKo0u6D4R6/hg=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.0.0.tgz",
+      "integrity": "sha512-u0Lw+IYlgbEJFF6/qAqG2d1jQmJl0eyAGJHoAJqr2HT4M2BNuQYSEiSE75f52pXHSJm8AlTjnLLbBFPrdz2hpA=="
     },
     "vscode-uri": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.3.tgz",
-      "integrity": "sha1-Yxvb9xbcyrDmUpGo3CXCMjIIWlI="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.2.tgz",
+      "integrity": "sha512-jkjy6pjU1fxUvI51P+gCsxg1u2n8LSt0W6KrCNQceaziKzff74GoWmjVG46KieVzybO1sttPQmYfrwSHey7GUA=="
     },
     "which": {
       "version": "2.0.2",

--- a/language-server/package.json
+++ b/language-server/package.json
@@ -31,15 +31,16 @@
   },
   "dependencies": {
     "azure-pipelines-language-service": "0.6.0",
-    "request-light": "0.2.3",
-    "vscode-languageserver": "4.1.2",
-    "vscode-languageserver-types": "3.6.1",
-    "vscode-nls": "3.2.2",
-    "vscode-uri": "1.0.3"
+    "request-light": "^0.4.0",
+    "vscode-languageserver": "^7.0.0",
+    "vscode-languageserver-textdocument": "^1.0.1",
+    "vscode-languageserver-types": "^3.16.0",
+    "vscode-nls": "^5.0.0",
+    "vscode-uri": "^3.0.2"
   },
   "devDependencies": {
     "@types/mocha": "5.2.5",
-    "@types/node": "9.6.6",
+    "@types/node": "^14.0.0",
     "coveralls": "^3.0.2",
     "mocha": "5.2.0",
     "mocha-junit-reporter": "1.18.0",
@@ -47,7 +48,7 @@
     "nyc": "^15.0.0",
     "source-map-support": "0.5.5",
     "ts-node": "7.0.1",
-    "typescript": "2.7.2"
+    "typescript": "^4.1.3"
   },
   "scripts": {
     "build": "npm run compile && npm pack",

--- a/language-server/test/autoCompletion.test.ts
+++ b/language-server/test/autoCompletion.test.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Red Hat. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { TextDocument } from 'vscode-languageserver-types';
+import { TextDocument } from 'vscode-languageserver-textdocument';
 import { LanguageService, getLanguageService } from 'azure-pipelines-language-service'
 import { schemaRequestService, workspaceContext }  from './testHelper';
 import { parse as parseYAML } from 'azure-pipelines-language-service';

--- a/language-server/test/autoCompletion2.test.ts
+++ b/language-server/test/autoCompletion2.test.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Red Hat. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { TextDocument } from 'vscode-languageserver';
+import { TextDocument } from 'vscode-languageserver-textdocument';
 import { LanguageService, getLanguageService } from 'azure-pipelines-language-service'
 import { schemaRequestService, workspaceContext }  from './testHelper';
 import { parse as parseYAML } from 'azure-pipelines-language-service';

--- a/language-server/test/autoCompletion3.test.ts
+++ b/language-server/test/autoCompletion3.test.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { TextDocument } from 'vscode-languageserver';
+import { TextDocument } from 'vscode-languageserver-textdocument';
 import { LanguageService, getLanguageService } from 'azure-pipelines-language-service'
 import { schemaRequestService, workspaceContext }  from './testHelper';
 import { parse as parseYAML } from 'azure-pipelines-language-service';

--- a/language-server/test/documentSymbols.test.ts
+++ b/language-server/test/documentSymbols.test.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Red Hat. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { TextDocument} from 'vscode-languageserver';
+import { TextDocument } from 'vscode-languageserver-textdocument';
 import {getLanguageService} from 'azure-pipelines-language-service'
 import {schemaRequestService, workspaceContext}  from './testHelper';
 import { parse as parseYAML } from 'azure-pipelines-language-service';
@@ -11,9 +11,9 @@ var assert = require('assert');
 let languageService = getLanguageService(schemaRequestService, [], null, workspaceContext);
 
 suite("Document Symbols Tests", () => {
-	
+
 	describe('Document Symbols Tests', function(){
-				
+
         function setup(content: string){
             return TextDocument.create("file://~/Desktop/vscode-k8s/test.yaml", "yaml", 0, content);
         }
@@ -27,64 +27,64 @@ suite("Document Symbols Tests", () => {
         it('Document is empty', (done) => {
             let content = "";
             let symbols = parseSetup(content);
-            assert.equal(symbols, null);	
+            assert.equal(symbols, null);
             done();
         })
 
         it('Simple document symbols', (done) => {
             let content = "cwd: test";
             let symbols = parseSetup(content);
-            assert.equal(symbols.length, 1);	
-            done();			
+            assert.equal(symbols.length, 1);
+            done();
         });
 
         it('Document Symbols with number', (done) => {
             let content = "node1: 10000";
             let symbols = parseSetup(content);
-            assert.equal(symbols.length, 1);	
-            done();			
+            assert.equal(symbols.length, 1);
+            done();
         });
 
         it('Document Symbols with boolean', (done) => {
             let content = "node1: False";
             let symbols = parseSetup(content);
-            assert.equal(symbols.length, 1);	
-            done();			
+            assert.equal(symbols.length, 1);
+            done();
         });
 
         it('Document Symbols with object', (done) => {
             let content = "scripts:\n  node1: test\n  node2: test";
             let symbols = parseSetup(content);
-            assert.equal(symbols.length, 3);	
-            done();			
+            assert.equal(symbols.length, 3);
+            done();
         });
 
         it('Document Symbols with null', (done) => {
             let content = "apiVersion: null";
             let symbols = parseSetup(content);
-            assert.equal(symbols.length, 1);	
-            done();			
+            assert.equal(symbols.length, 1);
+            done();
         });
 
         it('Document Symbols with array of strings', (done) => {
             let content = "items:\n  - test\n  - test";
             let symbols = parseSetup(content);
-            assert.equal(symbols.length, 1);	
-            done();			
+            assert.equal(symbols.length, 1);
+            done();
         });
 
         it('Document Symbols with array', (done) => {
             let content = "authors:\n  - name: Josh\n  - email: jp";
             let symbols = parseSetup(content);
-            assert.equal(symbols.length, 3);	
-            done();			
+            assert.equal(symbols.length, 3);
+            done();
         });
-    
+
         it('Document Symbols with object and array', (done) => {
             let content = "scripts:\n  node1: test\n  node2: test\nauthors:\n  - name: Josh\n  - email: jp";
             let symbols = parseSetup(content);
-            assert.equal(symbols.length, 6);	
-            done();			
+            assert.equal(symbols.length, 6);
+            done();
         });
     });
 });

--- a/language-server/test/formatter.test.ts
+++ b/language-server/test/formatter.test.ts
@@ -2,8 +2,7 @@
  *  Copyright (c) Red Hat. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import {
-    TextDocument} from 'vscode-languageserver';
+import { TextDocument } from 'vscode-languageserver-textdocument';
 import { getLanguageService } from 'azure-pipelines-language-service'
 import { schemaRequestService, workspaceContext } from './testHelper';
 var assert = require('assert');

--- a/language-server/test/hover.test.ts
+++ b/language-server/test/hover.test.ts
@@ -2,7 +2,8 @@
  *  Copyright (c) Red Hat. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { TextDocument, Hover, MarkupContent, MarkedString} from 'vscode-languageserver';
+import { Hover, MarkupContent, MarkedString} from 'vscode-languageserver/node';
+import { TextDocument } from 'vscode-languageserver-textdocument';
 import {getLanguageService} from 'azure-pipelines-language-service'
 import {schemaRequestService, workspaceContext}  from './testHelper';
 import { parse as parseYAML } from 'azure-pipelines-language-service';
@@ -50,11 +51,11 @@ export function assertHasContents(result: Hover): void {
 
 suite("Hover Tests", () => {
 
-	
+
 	describe('Yaml Hover with bowerrc', function(){
-		
+
 		describe('doComplete', function(){
-			
+
 			function setup(content: string): TextDocument{
 				return TextDocument.create("file://~/Desktop/vscode-k8s/test.yaml", "yaml", 0, content);
 			}
@@ -72,7 +73,7 @@ suite("Hover Tests", () => {
 					assertHasContents(result);
 				}).then(done, done);
             });
-            
+
             it('Hover on value on root', (done) => {
 				let content: string = "cwd: test";
 				let hover: Thenable<Hover> = parseSetup(content, 6);
@@ -99,12 +100,12 @@ suite("Hover Tests", () => {
 
             it('Hover works on both root node and child nodes works', (done) => {
 				let content: string = "scripts:\n  postinstall: test";
-                
+
                 let firstHover: Thenable<Hover> = parseSetup(content, 3);
                 firstHover.then(function(result: Hover){
 					assertHasContents(result);
                 });
-                
+
                 let secondHover: Thenable<Hover> = parseSetup(content, 15);
 				secondHover.then(function(result: Hover){
 					assertHasContents(result);

--- a/language-server/test/hover2.test.ts
+++ b/language-server/test/hover2.test.ts
@@ -2,8 +2,7 @@
  *  Copyright (c) Red Hat. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import {
-	TextDocument} from 'vscode-languageserver';
+import { TextDocument } from 'vscode-languageserver-textdocument';
 import {getLanguageService} from 'azure-pipelines-language-service'
 import {schemaRequestService, workspaceContext}  from './testHelper';
 import {assertHasContents} from './hover.test'
@@ -23,11 +22,11 @@ languageService.configure(languageSettings);
 
 suite("Hover Tests", () => {
 
-	
+
 	describe('Yaml Hover with composer schema', function(){
-		
+
 		describe('doComplete', function(){
-			
+
 			function setup(content: string){
 				return TextDocument.create("file://~/Desktop/vscode-k8s/test.yaml", "yaml", 0, content);
 			}
@@ -45,7 +44,7 @@ suite("Hover Tests", () => {
 					assertHasContents(result);
 				}).then(done, done);
             });
-            
+
             it('Hover works on array nodes 2', (done) => {
 				let content = "authors:\n  - name: Josh\n  - email: jp";
 				let hover = parseSetup(content, 28);

--- a/language-server/test/integration.test.ts
+++ b/language-server/test/integration.test.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Red Hat. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { TextDocument } from 'vscode-languageserver-types';
+import { TextDocument } from 'vscode-languageserver-textdocument';
 import { LanguageService, getLanguageService } from 'azure-pipelines-language-service'
 import { schemaRequestService, workspaceContext }  from './testHelper';
 import { parse as parseYAML } from 'azure-pipelines-language-service';

--- a/language-server/test/schemaNotFound.ts
+++ b/language-server/test/schemaNotFound.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Red Hat. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { TextDocument } from 'vscode-languageserver';
+import { TextDocument } from 'vscode-languageserver-textdocument';
 import {getLanguageService} from 'azure-pipelines-language-service'
 import {schemaRequestService, workspaceContext}  from './testHelper';
 import { parse as parseYAML } from 'azure-pipelines-language-service';
@@ -25,7 +25,7 @@ suite("Validation Tests", () => {
 
 	// Tests for validator
 	describe('Validation', function() {
-		
+
 		function setup(content: string){
 			return TextDocument.create("file://~/Desktop/vscode-k8s/test.yaml", "yaml", 0, content);
 		}
@@ -38,7 +38,7 @@ suite("Validation Tests", () => {
 
 		//Validating basic nodes
 		describe('Test that validation throws error when schema is not found', function(){
-			
+
 			it('Basic test', (done) => {
 				let content = `testing: true`;
 				let validator = parseSetup(content);

--- a/language-server/test/schemaValidation.test.ts
+++ b/language-server/test/schemaValidation.test.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Red Hat. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { TextDocument } from 'vscode-languageserver';
+import { TextDocument } from 'vscode-languageserver-textdocument';
 import {getLanguageService} from 'azure-pipelines-language-service'
 import {schemaRequestService, workspaceContext}  from './testHelper';
 import { parse as parseYAML } from 'azure-pipelines-language-service';
@@ -27,7 +27,7 @@ suite("Validation Tests", () => {
 
 	// Tests for validator
 	describe('Validation', function() {
-		
+
 		function setup(content: string){
 			return TextDocument.create("file://~/Desktop/vscode-k8s/test.yaml", "yaml", 0, content);
 		}
@@ -40,7 +40,7 @@ suite("Validation Tests", () => {
 
 		//Validating basic nodes
 		describe('Test that validation does not throw errors', function(){
-			
+
 			it('Basic test', (done) => {
 				let content = `analytics: true`;
 				let validator = parseSetup(content);
@@ -71,7 +71,7 @@ suite("Validation Tests", () => {
 				validator.then(function(result){
 					assert.equal(result.length, 0);
 				}).then(done, done);
-			});	
+			});
 
             it('Include with value should not error', (done) => {
 				let content = `customize: !include customize.yaml`;
@@ -161,7 +161,7 @@ suite("Validation Tests", () => {
 					validator.then(function(result){
 						assert.equal(result.length, 0);
 					}).then(done, done);
-				});			
+				});
 
 				it('Type Object does not error on valid node', (done) => {
 					let content = `registry:\n  search: test_url`;
@@ -169,7 +169,7 @@ suite("Validation Tests", () => {
 					validator.then(function(result){
 						assert.equal(result.length, 0);
 					}).then(done, done);
-				});		
+				});
 
 				it('Type Array does not error on valid node', (done) => {
 					let content = `resolvers:\n  - test\n  - test\n  - test`;
@@ -187,10 +187,10 @@ suite("Validation Tests", () => {
 					});
 					done();
 				});
-				
+
 			});
 
-		});	
+		});
 
 		describe('Test that validation DOES throw errors', function(){
 			it('Error when theres a finished untyped item', (done) => {
@@ -242,6 +242,6 @@ suite("Validation Tests", () => {
 			});
 
 		});
-	
+
 	});
 });

--- a/language-server/test/schemaValidation2.test.ts
+++ b/language-server/test/schemaValidation2.test.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { TextDocument } from 'vscode-languageserver';
+import { TextDocument } from 'vscode-languageserver-textdocument';
 import { LanguageService, getLanguageService, YAMLDocument, Diagnostic } from 'azure-pipelines-language-service'
 import { schemaRequestService, workspaceContext }  from './testHelper';
 import { parse as parseYAML } from 'azure-pipelines-language-service';

--- a/language-server/test/testHelper.ts
+++ b/language-server/test/testHelper.ts
@@ -2,23 +2,23 @@
 
 import {
 	IPCMessageReader, IPCMessageWriter,
-	createConnection, IConnection, TextDocumentSyncKind,
+	createConnection, Connection, TextDocumentSyncKind,
 	InitializeResult, RequestType
-} from 'vscode-languageserver';
+} from 'vscode-languageserver/node';
 import { xhr, XHRResponse, getErrorStatusDescription } from 'request-light';
 import Strings = require( 'azure-pipelines-language-service');
-import URI from 'vscode-uri';
+import { URI } from 'vscode-uri';
 import * as URL from 'url';
 import fs = require('fs');
 import { JSONSchema } from "azure-pipelines-language-service";
 import { ParseSchema } from "azure-pipelines-language-service";
 
 namespace VSCodeContentRequest {
-	export const type: RequestType<{}, {}, {}, {}> = new RequestType('vscode/content');
+	export const type: RequestType<{}, {}, {}> = new RequestType('vscode/content');
 }
 
 // Create a connection for the server.
-let connection: IConnection = null;
+let connection: Connection = null;
 if (process.argv.indexOf('--stdio') == -1) {
 	connection = createConnection(new IPCMessageReader(process), new IPCMessageWriter(process));
 } else {

--- a/language-service/package-lock.json
+++ b/language-service/package-lock.json
@@ -143,9 +143,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "9.6.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.6.tgz",
-      "integrity": "sha512-SJe0g5cZeGNDP5sD8mIX3scb+eq8LQQZ60FXiKZHipYSeEFZ5EKml+NNMiO76F74TY4PoMWlNxF/YRY40FOvZQ==",
+      "version": "14.14.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.25.tgz",
+      "integrity": "sha512-EPpXLOVqDvisVxtlbvzfyqSsFeQxltFbluZNRndIb8tr9KiBnYNLzrc1N3pyKUCww2RNrfHDViqDWWE1LCJQtQ==",
       "dev": true
     },
     "@webassemblyjs/ast": {
@@ -2489,7 +2489,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true
     },
@@ -3221,7 +3221,7 @@
     },
     "json5": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
     },
@@ -3525,7 +3525,7 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
     },
@@ -3579,7 +3579,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         }
@@ -5507,9 +5507,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.7.2",
-      "resolved": "http://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
-      "integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
       "dev": true
     },
     "uglify-js": {
@@ -5733,37 +5733,53 @@
       "dev": true
     },
     "vscode-json-languageservice": {
-      "version": "3.0.12",
-      "resolved": "http://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-3.0.12.tgz",
-      "integrity": "sha512-XSgRVY/vsPqOa//ZwLD5DWx1wzTQGgeZfsOlVqFlLya10dpimSnd27kbuL45hzxh4B+MvmHZtZeWQKjSYnNF0A==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-4.0.2.tgz",
+      "integrity": "sha512-d8Ahw990Cq/G60CzN26rehXcbhbMgMGMmXeN6C/V/RYZUhfs16EELRK+EL7b/3Y8ZGshtKqboePSeDVa94qqFg==",
       "requires": {
-        "jsonc-parser": "^2.0.0-next.1",
-        "vscode-languageserver-types": "^3.6.1",
-        "vscode-nls": "^3.2.1",
-        "vscode-uri": "^1.0.3"
+        "jsonc-parser": "^3.0.0",
+        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-languageserver-types": "^3.16.0",
+        "vscode-nls": "^5.0.0",
+        "vscode-uri": "^3.0.2"
       },
       "dependencies": {
         "jsonc-parser": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.0.0.tgz",
-          "integrity": "sha512-gYk8VcFDwky0AjrKeJSWgCm/lYGteP9hszGWtgg67Elz4owvhJF9qATjuIRAk5jgBMGM65MPAc+I4RTeoqoykA=="
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+          "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA=="
+        },
+        "vscode-nls": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.0.0.tgz",
+          "integrity": "sha512-u0Lw+IYlgbEJFF6/qAqG2d1jQmJl0eyAGJHoAJqr2HT4M2BNuQYSEiSE75f52pXHSJm8AlTjnLLbBFPrdz2hpA=="
+        },
+        "vscode-uri": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.2.tgz",
+          "integrity": "sha512-jkjy6pjU1fxUvI51P+gCsxg1u2n8LSt0W6KrCNQceaziKzff74GoWmjVG46KieVzybO1sttPQmYfrwSHey7GUA=="
         }
       }
     },
+    "vscode-languageserver-textdocument": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.1.tgz",
+      "integrity": "sha512-UIcJDjX7IFkck7cSkNNyzIz5FyvpQfY7sdzVy+wkKN/BLaD4DQ0ppXQrKePomCxTS7RrolK1I0pey0bG9eh8dA=="
+    },
     "vscode-languageserver-types": {
-      "version": "3.6.1",
-      "resolved": "http://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.6.1.tgz",
-      "integrity": "sha512-Npi3i8gUWcx5h8z5idNqPKBLJmZothXK2FSG4csEmxAR7avb8W6l9Ny+VW9yCUB3bOdD7iXfah8IO0AS1jwQmQ=="
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
+      "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
     },
     "vscode-nls": {
-      "version": "3.2.2",
-      "resolved": "http://registry.npmjs.org/vscode-nls/-/vscode-nls-3.2.2.tgz",
-      "integrity": "sha512-/Ur1+tgazwd51+ncRyoy0UIu4dvMdVXS9XMUULQlZIBoNGEwOhwEx9x+hHWoUjldMrOQ32t2CGKo0u6D4R6/hg=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.0.0.tgz",
+      "integrity": "sha512-u0Lw+IYlgbEJFF6/qAqG2d1jQmJl0eyAGJHoAJqr2HT4M2BNuQYSEiSE75f52pXHSJm8AlTjnLLbBFPrdz2hpA=="
     },
     "vscode-uri": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.3.tgz",
-      "integrity": "sha1-Yxvb9xbcyrDmUpGo3CXCMjIIWlI="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.2.tgz",
+      "integrity": "sha512-jkjy6pjU1fxUvI51P+gCsxg1u2n8LSt0W6KrCNQceaziKzff74GoWmjVG46KieVzybO1sttPQmYfrwSHey7GUA=="
     },
     "watchpack": {
       "version": "1.6.0",
@@ -5978,7 +5994,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {

--- a/language-service/package.json
+++ b/language-service/package.json
@@ -34,15 +34,15 @@
   "dependencies": {
     "js-yaml": "3.13.1",
     "jsonc-parser": "2.0.2",
-    "vscode-json-languageservice": "3.0.12",
-    "vscode-languageserver-types": "3.6.1",
-    "vscode-nls": "3.2.2",
-    "vscode-uri": "1.0.3",
+    "vscode-json-languageservice": "^4.0.2",
+    "vscode-languageserver-types": "^3.16.0",
+    "vscode-nls": "^5.0.0",
+    "vscode-uri": "^3.0.2",
     "yaml-ast-parser": "0.0.40"
   },
   "devDependencies": {
     "@types/mocha": "5.2.5",
-    "@types/node": "9.6.6",
+    "@types/node": "^14.0.0",
     "coveralls": "^3.0.2",
     "mocha": "5.2.0",
     "mocha-junit-reporter": "1.18.0",
@@ -52,8 +52,9 @@
     "source-map-support": "0.5.5",
     "ts-loader": "5.2.1",
     "ts-node": "7.0.1",
-    "typescript": "2.7.2",
+    "typescript": "^4.1.3",
     "uglifyjs-webpack-plugin": "^2.2.0",
+    "vscode-languageserver-textdocument": "^1.0.1",
     "webpack": "^4.41.5",
     "webpack-cli": "3.1.2"
   },

--- a/language-service/src/parser/jsonParser.ts
+++ b/language-service/src/parser/jsonParser.ts
@@ -165,7 +165,7 @@ export class ASTNode {
 		if (!matchingSchemas.include(this)) {
 			return;
 		}
-		
+
 		if (Array.isArray(schema.type)) {
 			if ((<string[]>schema.type).indexOf(this.type) === -1) {
 				//allow numbers to be validated as strings
@@ -189,7 +189,7 @@ export class ASTNode {
 					validationResult.addProblem({
 						location: { start: this.start, end: this.end },
 						severity: ProblemSeverity.Warning,
-						getMessage: () => schema.errorMessage || localize('typeMismatchWarning', 'Incorrect type. Expected "{0}".', schema.type)
+						getMessage: () => schema.errorMessage || localize('typeMismatchWarning', 'Incorrect type. Expected "{0}".', schema.type as string)
 					});
 				}
 			}
@@ -313,7 +313,7 @@ export class ASTNode {
 				getMessage: () => localize('minLengthWarning', 'String is shorter than the minimum length of {0}.', schema.minLength)
 			});
 		}
-	
+
 		if (schema.maxLength && value.length > schema.maxLength) {
 			validationResult.addProblem({
 				location: { start: this.start, end: this.end },
@@ -321,7 +321,7 @@ export class ASTNode {
 				getMessage: () => localize('maxLengthWarning', 'String is longer than the maximum length of {0}.', schema.maxLength)
 			});
 		}
-	
+
 		if (schema.pattern) {
 			const flags: string = ASTNode.getIgnoreValueCase(schema) ? "i" : "";
 			const regex: RegExp = new RegExp(schema.pattern, flags);
@@ -732,7 +732,7 @@ export class ObjectASTNode extends ASTNode {
 		let seenKeys: ASTNodeMap = Object.create(null);
 		let unprocessedProperties: string[] = [];
 		this.properties.forEach((node) => {
-			
+
 			const key: string = node.key.value;
 
 			//Replace the merge key with the actual values of what the node value points to in seen keys
@@ -814,7 +814,7 @@ export class ObjectASTNode extends ASTNode {
 					}
 				}
 			}
-			
+
 			return false;
 		}
 

--- a/language-service/src/services/jsonSchemaService.ts
+++ b/language-service/src/services/jsonSchemaService.ts
@@ -7,7 +7,7 @@
 
 import Json = require('jsonc-parser');
 import {JSONSchema, JSONSchemaMap} from '../jsonSchema';
-import URI from 'vscode-uri';
+import {URI} from 'vscode-uri';
 import Strings = require('../utils/strings');
 import {SchemaRequestService, WorkspaceContextService, PromiseConstructor, Thenable} from '../yamlLanguageService';
 

--- a/language-service/test/pipelinesTests/yamlTraversal.test.ts
+++ b/language-service/test/pipelinesTests/yamlTraversal.test.ts
@@ -1,7 +1,8 @@
 import * as assert from 'assert';
 import * as yamlparser from '../../src/parser/yamlParser'
 import { YAMLTraversal, YamlNodeInfo, YamlNodePropertyValues } from '../../src/services/yamlTraversal';
-import { TextDocument, Position } from 'vscode-languageserver-types';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { Position } from 'vscode-languageserver-types';
 
 suite("Yaml Traversal Service Tests", function () {
     this.timeout(20000);
@@ -93,7 +94,7 @@ suite("Yaml Traversal Service Tests", function () {
         assert.equal(results.values["arguments"], "--configuration $(BuildConfiguration)");
         assert.equal(results.values["publishTestResults"], true);
     });
-    
+
     test('fail to get inputs', async function () {
       const results = findInputs(testYaml(), { line: 3, character: 2 });
       assert.equal(results.values, null);
@@ -119,9 +120,9 @@ function findInputs(content: string, position: Position): YamlNodePropertyValues
 function testYaml(): string {
     return `variables:
       BuildConfiguration: Release
-    
+
     steps:
-    
+
       - task: DotNetCoreCLI@2
         name: Test
         inputs:
@@ -129,13 +130,13 @@ function testYaml(): string {
           projects: "**/*Test*/*.csproj"
           arguments: "--configuration $(BuildConfiguration)"
           publishTestResults: true
-    
+
       - task: DotNetCoreCLI@2
         name: Publish
         inputs:
           command: publish
           arguments: "--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory)"
-    
+
       - task: PublishBuildArtifacts@1
         name: Artifacts
         inputs:

--- a/language-service/test/pipelinesTests/yamlcompletion.test.ts
+++ b/language-service/test/pipelinesTests/yamlcompletion.test.ts
@@ -3,7 +3,8 @@ import { YAMLCompletion } from '../../src/services/yamlCompletion';
 import * as JSONSchemaService from '../../src/services/jsonSchemaService';
 import { JSONSchema } from '../../src/jsonSchema';
 import * as URL from 'url';
-import { TextDocument, Position, CompletionList } from 'vscode-languageserver-types';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { Position, CompletionList } from 'vscode-languageserver-types';
 import * as yamlparser from '../../src/parser/yamlParser'
 import { Thenable } from '../../src/yamlLanguageService';
 import * as assert from 'assert';
@@ -51,7 +52,7 @@ suite("Yaml Completion Service Tests", function () {
     });
 
     test ('case insensitive matching keys are not suggested', async function() {
-        //first make sure that the azureAppServiceManage is still in the schema and has an Action input 
+        //first make sure that the azureAppServiceManage is still in the schema and has an Action input
         {
             const list = await runTaskCompletionItemsTest('steps:\n- task: azureAppServiceManage@0\n  inputs:\n    ', {line: 3, character: 4}, {minimum: 6});
             const labels = list.items.map(item => item.label);

--- a/language-service/test/pipelinesTests/yamlvalidation.test.ts
+++ b/language-service/test/pipelinesTests/yamlvalidation.test.ts
@@ -3,7 +3,8 @@ import { YAMLValidation } from '../../src/services/yamlValidation';
 import * as JSONSchemaService from '../../src/services/jsonSchemaService';
 import { JSONSchema } from '../../src/jsonSchema';
 import * as URL from 'url';
-import { TextDocument, Position, Diagnostic } from 'vscode-languageserver-types';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { Position, Diagnostic } from 'vscode-languageserver-types';
 import * as yamlparser from '../../src/parser/yamlParser'
 import { Thenable } from '../../src/yamlLanguageService';
 import * as assert from 'assert';


### PR DESCRIPTION
There are no functional changes included in this PR, other than some (rather large) dependency bumps to get webpack working. Necessary to enable webpacking on the client side: microsoft/azure-pipelines-vscode#380.

All tests pass (note: they're broken without some modifications; will figure that out later) and basic smoke testing indicates that the server is still working as intended.