### PR TITLE
Support dynamically-generated variables

### DIFF
--- a/language-service/test/pipelinesTests/yamlvalidation.test.ts
+++ b/language-service/test/pipelinesTests/yamlvalidation.test.ts
@@ -51,6 +51,14 @@ steps:
 `);
         assert.equal(diagnostics.length, 0);
     });
+
+    it('validates pipelines with dynamically-generated variables', async function () {
+        const diagnostics = await runValidationTest(`
+variables:
+  \${{ parameters.environment }}Release: true
+`);
+      assert.equal(diagnostics.length, 0);
+    });
 });
 
 const workspaceContext = {


### PR DESCRIPTION
Turns out the }} is needed after all :).