### PR TITLE
Handle scalar properties with dynamic keys

### DIFF
--- a/language-service/test/pipelinesTests/yamlvalidation.test.ts
+++ b/language-service/test/pipelinesTests/yamlvalidation.test.ts
@@ -106,7 +106,19 @@ steps:
       '\${{ pair.value }}': error
 `);
         assert.equal(diagnostics.length, 0);
-    })
+    });
+
+    it('validates pipelines that has an object with a dynamic key and scalar value as the first property', async function () {
+      // Note: the real purpose of this test is to ensure we don't throw,
+      // but I can't figure out how to assert that yet.
+      // diagnostics.length can be whatever, as long as we get to that point :).
+      const diagnostics = await runValidationTest(`
+steps:
+- \${{ each shorthand in parameters.taskShorthands }}:
+  - \${{ shorthand }}: echo 'Hi'
+`);
+      assert.equal(diagnostics.length, 2);
+    });
 });
 
 const workspaceContext = {


### PR DESCRIPTION
This handles a case where, when looping through a sequence (array) of items, we would see a map (object) with a dynamic expression as the key but a scalar as the value and not know what to do with it (leading to a proactive error being thrown).

In the general case, when the first item in a sequence (array) is a map with an expression as the key, that means the key will vanish at compile time, and we should hoist its children up as the "real" values instead. However, that doesn't hold true when the value is a simple scalar. In that case, we do need to preserve the key and treat it as a regular key/value pair.

Because it took me way too long to re-understand this code (and I wrote it not too long ago!), I've added extensive comments to hopefully make it easier for the next person.