### PR TITLE
'continueOnError' parameter only accepts boolean literals #493

### DIFF
--- a/language-service/src/parser/jsonParser.ts
+++ b/language-service/src/parser/jsonParser.ts
@@ -189,6 +189,7 @@ export class ASTNode {
 					let isVariableExpression = false;
 
 					if (this.type === 'string') {
+						// Ignore expressions as those will be replaced by Azure Pipelines
 						const currentValue = String(this.getValue());
 	
 						isVariableExpression = (currentValue.startsWith('${{') && currentValue.endsWith("}}"))

--- a/language-service/src/parser/jsonParser.ts
+++ b/language-service/src/parser/jsonParser.ts
@@ -184,8 +184,18 @@ export class ASTNode {
 		}
 		else if (schema.type) {
 			if (this.type !== schema.type) {
+				if (
+					this.type === 'string'
+					&& /^\$({{.*}}|\[.*\]|\(.*\))$/.test(this.getValue())
+				) {
+					validationResult.addProblem({
+						location: { start: this.start, end: this.end },
+						severity: ProblemSeverity.Hint,
+						getMessage: () => localize('typeMismatchWarning', 'Extension can not check types of variables in runtime execution.')
+					});
+				}
 				//count strings that look like numbers as strings
-				if (this.type != "number" || schema.type != "string") {
+				else if (this.type != "number" || schema.type != "string") {
 					validationResult.addProblem({
 						location: { start: this.start, end: this.end },
 						severity: ProblemSeverity.Warning,


### PR DESCRIPTION
- add warning message for variables types checking

Issue: [#493](https://github.com/microsoft/azure-pipelines-vscode/issues/493)