### PR TITLE
Only check for expressions when keys are scalar

### DIFF
--- a/language-service/test/pipelinesTests/yamlvalidation.test.ts
+++ b/language-service/test/pipelinesTests/yamlvalidation.test.ts
@@ -119,6 +119,22 @@ steps:
 `);
       assert.equal(diagnostics.length, 2);
     });
+
+    it('validates incorrectly-indented pipelines that look like they have an array property', async function () {
+      // Note: the real purpose of this test is to ensure we don't throw,
+      // but I can't figure out how to assert that yet.
+      // diagnostics.length can be whatever, as long as we get to that point :).
+      const diagnostics = await runValidationTest(`
+steps:
+- task: PowerShellOnTargetMachines@3
+  inputs:
+    Machines: EXAMPLE
+    InlineScript: |
+    [System.Reflection.Assembly]::LoadWithPartialName("System.IO.Compression.FileSystem") | Out-Null
+    CommunicationProtocol: Http);
+`);
+      assert.equal(diagnostics.length, 4);
+    });
 });
 
 const workspaceContext = {


### PR DESCRIPTION
Compile-time expressions must have scalar keys; e.g. `[array]: value` will never be an expression. We now check the node to make sure it's scalar before seeing if it has a value to prevent the language server from crashing.

Fixes #140