### PR TITLE
Language fixes

### DIFF
--- a/language-server/src/server.ts
+++ b/language-server/src/server.ts
@@ -79,7 +79,7 @@ documents.listen(connection);
 let clientDynamicRegisterSupport = false;
 let hasWorkspaceFolderCapability = false;
 
-// After the server has started the client sends an initilize request. The server receives
+// After the server has started the client sends an initialize request. The server receives
 // in the passed params the rootPath of the workspace plus the client capabilities.
 let capabilities: ClientCapabilities;
 let workspaceFolders = [];

--- a/language-service/README.md
+++ b/language-service/README.md
@@ -21,20 +21,14 @@
 ## Language Server Settings
 
 The following settings are supported:
+
 * `yaml.format.enable`: Enable/disable default YAML formatter
 * `yaml.validate`: Enable/disable validation feature
 * `yaml.schemas`: Helps you associate schemas with files in a glob pattern
 * `yaml.customTags`: Array of custom tags that the parser will validate against. It has two ways to be used. Either an item in the array is a custom tag such as "!Ref" or you can specify the type of the object !Ref should be by doing "!Ref scalar". For example: ["!Ref", "!Some-Tag scalar"]. The type of object can be one of scalar, sequence, mapping, map.
 
-## Language Server Settings
+##### Associating a schema to a glob pattern via yaml.schemas:
 
-The following settings are supported:
-* `yaml.format.enable`: Enable/disable default YAML formatter
-* `yaml.validate`: Enable/disable validation feature
-* `yaml.schemas`: Helps you associate schemas with files in a glob pattern
-* `yaml.customTags`: Array of custom tags that the parser will validate against. It has two ways to be used. Either an item in the array is a custom tag such as "!Ref" or you can specify the type of the object !Ref should be by doing "!Ref scalar". For example: ["!Ref", "!Some-Tag scalar"]. The type of object can be one of scalar, sequence, mapping, map.
-
-##### Associating a schema to a glob pattern via yaml.schemas: 
 When associating a schema it should follow the format below
 ```
 yaml.schemas: {

--- a/language-service/src/parser/jsonParser.ts
+++ b/language-service/src/parser/jsonParser.ts
@@ -289,7 +289,7 @@ export class ASTNode {
 				const ignoreCase: boolean = ASTNode.getIgnoreValueCase(schema);
 				for (const e of schema.enum) {
 					if (objects.equals(val, e) ||
-					   (ignoreCase && typeof e === "string" && typeof val === "string" && e.toUpperCase() === val.toUpperCase())) {
+						(ignoreCase && typeof e === "string" && typeof val === "string" && e.toUpperCase() === val.toUpperCase())) {
 						enumValueMatch = true;
 						break;
 					}
@@ -398,9 +398,9 @@ export class BooleanASTNode extends ASTNode {
 
 		//allow empty values to validate as strings
 		if (schema.type === 'string') {
-			//The pipeline parser allows expressions that evaulate to booleans and right now
-			//the generated schema is not prescise about that and allows any string.  The
-			//values 'true' and 'false' get parsed into BooleanASTNode's but we need to
+			//The pipeline parser allows expressions that evaluate to booleans and right now
+			//the generated schema is not precise about that and allows any string.  The
+			//values 'true' and 'false' get parsed into BooleanASTNodes but we need to
 			//allow them to match against 'string' in the schema.
 			this.validateStringValue(schema, '' + this.getValue(), validationResult);
 		}
@@ -1011,9 +1011,9 @@ export class ObjectASTNode extends ASTNode {
 							}
 						});
 					} else if (propertyDep) {
-						let propertyvalidationResult = new ValidationResult();
-						this.validate(propertyDep, propertyvalidationResult, matchingSchemas);
-						validationResult.mergePropertyMatch(propertyvalidationResult);
+						let propertyValidationResult = new ValidationResult();
+						this.validate(propertyDep, propertyValidationResult, matchingSchemas);
+						validationResult.mergePropertyMatch(propertyValidationResult);
 					}
 				}
 			});

--- a/language-service/src/services/yamlHover.ts
+++ b/language-service/src/services/yamlHover.ts
@@ -82,12 +82,12 @@ export class YAMLHover {
                 let markdownDescription: string = null;
                 let markdownEnumValueDescription: string = null;
                 let enumValue: string = null;
-                let deprectatedDescription: string = null;
+                let deprecatedDescription: string = null;
                 matchingSchemas.every((s) => {
                     if (s.node === node && !s.inverted && s.schema) {
                         title = title || s.schema.title;
                         markdownDescription = markdownDescription || s.schema["markdownDescription"] || toMarkdown(s.schema.description);
-                        deprectatedDescription = deprectatedDescription || s.schema["deprecationMessage"];
+                        deprecatedDescription = deprecatedDescription || s.schema["deprecationMessage"];
                         if (s.schema.enum)  {
                             let idx = s.schema.enum.indexOf(node.getValue());
                             if (s.schema["markdownEnumDescriptions"]) {
@@ -107,8 +107,8 @@ export class YAMLHover {
                 });
 
                 let result = '';
-                if (deprectatedDescription) {
-                    result = toMarkdown(deprectatedDescription);
+                if (deprecatedDescription) {
+                    result = toMarkdown(deprecatedDescription);
                 }
 
                 if (title) {

--- a/language-service/src/services/yamlValidation.ts
+++ b/language-service/src/services/yamlValidation.ts
@@ -88,12 +88,12 @@ export class YAMLValidation {
 		const translateSeverity = (problemSeverity: ProblemSeverity): DiagnosticSeverity => {
 			if (problemSeverity === ProblemSeverity.Error) {
 				return DiagnosticSeverity.Error;
-			 }
-			 if (problemSeverity == ProblemSeverity.Warning) {
-				 return DiagnosticSeverity.Warning;
-			 }
+			}
+			if (problemSeverity == ProblemSeverity.Warning) {
+				return DiagnosticSeverity.Warning;
+			}
 
-			 return DiagnosticSeverity.Hint;
+			return DiagnosticSeverity.Hint;
 		};
 
 		return this.jsonSchemaService.getSchemaForResource(textDocument.uri).then(function (schema) {
@@ -142,7 +142,7 @@ export class YAMLValidation {
 					}
 				});
 
-				if(schema.errors.length > 0) {
+				if (schema.errors.length > 0) {
 					for(let curDiagnostic of schema.errors){
 						diagnostics.push({
 							severity: DiagnosticSeverity.Error,

--- a/language-service/src/utils/uri.ts
+++ b/language-service/src/utils/uri.ts
@@ -294,13 +294,13 @@ export default class URI {
 			}
 		}
 		if (path) {
-			// lower-case windown drive letters in /C:/fff
+			// lower-case Windows drive letters in /C:/fff
 			const m = URI._upperCaseDrive.exec(path);
 			if (m) {
 				path = m[1] + m[2].toLowerCase() + path.substr(m[1].length + m[2].length);
 			}
 
-			// encode every segement but not slashes
+			// encode every segment but not slashes
 			// make sure that # and ? are always encoded
 			// when occurring in paths - otherwise the result
 			// cannot be parsed back again


### PR DESCRIPTION
- remove duplicate paragraph in language service readme
- fix various spelling/capitalization/grammar issues
- fix minor whitespace inconsistencies and markdownlint violations