### PR TITLE
Feat: Add "Definition" Support for for template Entries 

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@
     * Hovering over a node shows description *if available*
 5. Document outlining:
     * Shows a complete document outline of all nodes in the document
+6. Go to definition for Templates
+    * Referenced templates can be resolved to a local file (if it exists)
 
 ## Developer Support
 

--- a/language-server/src/server.ts
+++ b/language-server/src/server.ts
@@ -9,7 +9,7 @@
 import {
 	createConnection, Connection,
 	TextDocuments, InitializeParams, InitializeResult, NotificationType, RequestType,
-	DocumentFormattingRequest, Disposable, ProposedFeatures, CompletionList, TextDocumentSyncKind, ClientCapabilities
+	DocumentFormattingRequest, Disposable, ProposedFeatures, CompletionList, TextDocumentSyncKind, ClientCapabilities, DefinitionParams,
 } from "vscode-languageserver/node";
 import { TextDocument } from 'vscode-languageserver-textdocument';
 
@@ -104,6 +104,7 @@ connection.onInitialize((params: InitializeParams): InitializeResult => {
 			textDocumentSync: TextDocumentSyncKind.Full,
 			completionProvider: { resolveProvider: true },
 			hoverProvider: true,
+			definitionProvider: true,
 			documentSymbolProvider: true,
 			documentFormattingProvider: false
 		}
@@ -494,5 +495,16 @@ connection.onDocumentFormatting(formatParams => {
 
 	return customLanguageService.doFormat(document, formatParams.options, customTags);
 });
+
+connection.onDefinition((definitionParams: DefinitionParams) => {
+	let document = documents.get(definitionParams.textDocument.uri);
+
+	if(!document){
+		return;
+	}
+
+	let jsonDocument = parseYAML(document.getText());
+	return customLanguageService.doDefinition(document, definitionParams.position, jsonDocument, workspaceRoot);
+})
 
 connection.listen();

--- a/language-server/src/server.ts
+++ b/language-server/src/server.ts
@@ -87,7 +87,7 @@ let workspaceRoot: URI;
 connection.onInitialize((params: InitializeParams): InitializeResult => {
 	capabilities = params.capabilities;
 	workspaceFolders = params["workspaceFolders"];
-	workspaceRoot = URI.parse(params.rootPath);
+	workspaceRoot = URI.parse(params.rootUri, true);
 
 	function hasClientCapability(...keys: string[]) {
 		let c = params.capabilities;

--- a/language-service/src/services/yamlDefinition.ts
+++ b/language-service/src/services/yamlDefinition.ts
@@ -7,7 +7,7 @@
 
 import { YAMLDocument } from "../parser/yamlParser";
 import { PromiseConstructor, Thenable } from "vscode-json-languageservice";
-import { TextDocument, Position, Definition, Location } from "vscode-languageserver-types";
+import { TextDocument, Position, Definition, Location, Range } from "vscode-languageserver-types";
 import { URI, Utils } from "vscode-uri";
 
 export class YAMLDefinition {
@@ -45,21 +45,20 @@ export class YAMLDefinition {
         }
 
         // determine if abs path (from root) or relative path
-        let pathToDefinition = '';
+        // NOTE: Location.create takes in a string, even though the parameter is called 'uri'.
+        // So create an actual URI, then .toString() it and skip the unnecessary encoding.
+        let definitionUri = '';
         if (location.startsWith('/')) {
-            pathToDefinition = Utils.joinPath(workspaceRoot, location).fsPath;
+            definitionUri = Utils.joinPath(workspaceRoot, location).toString(true);
         }
         else {
-            pathToDefinition = Utils.resolvePath(
-                Utils.dirname(URI.parse(document.uri)),
+            definitionUri = Utils.resolvePath(
+                Utils.dirname(URI.parse(document.uri, true)),
                 location
-            ).fsPath;
+            ).toString(true);
         }
-        
-        const definition = Location.create(pathToDefinition, {
-            start: { line: 0, character: 0 },
-            end: { line: 0, character: 0 }
-          });
+
+        const definition = Location.create(definitionUri, Range.create(0, 0, 0, 0));
 
         return this.promise.resolve(definition);
     }

--- a/language-service/src/services/yamlDefinition.ts
+++ b/language-service/src/services/yamlDefinition.ts
@@ -47,7 +47,7 @@ export class YAMLDefinition {
             .split('@');
 
         // cannot jump to external resources
-        if (resource && resource != 'self') {
+        if (resource && resource !== 'self') {
             return this.promise.resolve(void 0);
         }
 

--- a/language-service/src/services/yamlDefinition.ts
+++ b/language-service/src/services/yamlDefinition.ts
@@ -38,7 +38,7 @@ export class YAMLDefinition {
 
         const [value, repo] = node
             .getValue()
-            .split('@')[0] // strip off the @ suffix if any
+            .split('@');
 
         // cannot jump to external resources
         if (repo && repo != 'self') {
@@ -50,9 +50,6 @@ export class YAMLDefinition {
         if (value.startsWith('/')) {
             const rootDir: string = workspaceRoot.path.toString();
             pathToDefinition = join(rootDir, value);
-
-            const foo = rootDir + '';
-            console.log(foo);
         }
         else {
             const documentPath: string = new URL(document.uri).pathname;

--- a/language-service/src/services/yamlDefinition.ts
+++ b/language-service/src/services/yamlDefinition.ts
@@ -47,13 +47,13 @@ export class YAMLDefinition {
         // determine if abs path (from root) or relative path
         let pathToDefinition = '';
         if (location.startsWith('/')) {
-            pathToDefinition = Utils.joinPath(workspaceRoot, location).path;
+            pathToDefinition = Utils.joinPath(workspaceRoot, location).fsPath;
         }
         else {
             pathToDefinition = Utils.resolvePath(
                 Utils.dirname(URI.parse(document.uri)),
                 location
-            ).path;
+            ).fsPath;
         }
         
         const definition = Location.create(pathToDefinition, {

--- a/language-service/src/services/yamlDefinition.ts
+++ b/language-service/src/services/yamlDefinition.ts
@@ -32,9 +32,8 @@ export class YAMLDefinition {
         const node = jsonDocument.getNodeFromOffset(offset);
 
         // can only jump to definition for template declaration, which means:
-        // * we must be on a string node (key: value)
+        // * we must be on a string node that is acting as a value (vs a key)
         // * the key (location) must be "template"
-        // * we must be on the _value_ of the node
         //
         // In other words...
         // - template: my_cool_template.yml

--- a/language-service/src/services/yamlDefinition.ts
+++ b/language-service/src/services/yamlDefinition.ts
@@ -1,0 +1,82 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+'use strict';
+
+import { resolve, dirname, join } from "path";
+import { JSONWorkerContribution } from "../jsonContributions";
+import { YAMLDocument } from "../parser/yamlParser";
+import * as SchemaService from "./jsonSchemaService";
+import { PromiseConstructor, Thenable } from "vscode-json-languageservice";
+import { TextDocument, Position, Definition, Location } from "vscode-languageserver-types";
+import { URI } from "vscode-uri";
+
+export class YAMLDefinition {
+
+    private schemaService: SchemaService.IJSONSchemaService;
+    private contributions: JSONWorkerContribution[];
+    private promise: PromiseConstructor;
+
+    constructor(schemaService: SchemaService.IJSONSchemaService, contributions: JSONWorkerContribution[] = [], promiseConstructor: PromiseConstructor) {
+        this.schemaService = schemaService;
+        this.contributions = contributions;
+        this.promise = promiseConstructor || Promise;
+    }
+
+    public doDefinition(document: TextDocument, position: Position, yamlDocument: YAMLDocument, workspaceRoot: URI): Thenable<Definition> {
+        const offset = document.offsetAt(position);
+
+        const jsonDocument = yamlDocument.documents.length > 0 ? yamlDocument.documents[0] : null;
+        if(jsonDocument === null){
+            return this.promise.resolve(void 0);
+        }
+        let node = jsonDocument.getNodeFromOffset(offset);
+        if (!node || (node.type === 'object' || node.type === 'array') && offset > node.start + 1 && offset < node.end - 1) {
+            return this.promise.resolve(void 0);
+        }
+        
+        // can only jump to definition for template declaration
+        // TODO use schema service to do this better
+        if (node.location !== 'template') {
+            return this.promise.resolve(void 0);
+        }
+
+        const value = node
+            .getValue()
+            .split('@')[0] // strip off the @ suffix if any
+
+        // determine if abs path (from root) or relative path
+        let pathToDefinition = '';
+        if (value.startsWith('/')) {
+            const rootDir: string = workspaceRoot.path.toString();
+            pathToDefinition = join(rootDir, value);
+
+            const foo = rootDir + '';
+            console.log(foo);
+        }
+        else {
+            const documentPath: string = new URL(document.uri).pathname;
+            pathToDefinition = resolve(dirname(documentPath), value);
+        }
+        
+        const definition = Location.create(pathToDefinition, {
+            start: { line: 0, character: 0 },
+            end: { line: 0, character: 0 }
+          });
+
+        return this.promise.resolve(definition);
+    }
+
+    // dummy methods to make code compile
+    public getSchemaService() {
+        return this.schemaService;
+    }
+
+    public getContributions() {
+        return this.contributions;
+    }
+
+}
+

--- a/language-service/src/yamlLanguageService.ts
+++ b/language-service/src/yamlLanguageService.ts
@@ -5,12 +5,14 @@
  *--------------------------------------------------------------------------------------------*/
 import { JSONSchemaService, CustomSchemaProvider } from './services/jsonSchemaService'
 import { TextDocument, Position, CompletionList, FormattingOptions, Diagnostic,
-  CompletionItem, TextEdit, Hover, SymbolInformation
+  CompletionItem, TextEdit, Hover, SymbolInformation, Definition
 } from 'vscode-languageserver-types';
+import { URI } from "vscode-uri";
 import { JSONSchema } from './jsonSchema';
 import { YAMLDocumentSymbols } from './services/documentSymbols';
 import { YAMLCompletion } from "./services/yamlCompletion";
 import { YAMLHover } from "./services/yamlHover";
+import { YAMLDefinition } from "./services/yamlDefinition";
 import { YAMLValidation } from "./services/yamlValidation";
 import { format } from './services/yamlFormatter';
 import { JSONWorkerContribution } from './jsonContributions';
@@ -99,6 +101,7 @@ export interface LanguageService {
 	doComplete(document: TextDocument, position: Position, yamlDocument: YAMLDocument): Thenable<CompletionList>;
   doValidation(document: TextDocument, yamlDocument: YAMLDocument): Thenable<Diagnostic[]>;
   doHover(document: TextDocument, position: Position, doc: YAMLDocument): Thenable<Hover>;
+  doDefinition(document: TextDocument, position: Position, doc: YAMLDocument, workspaceRoot: URI): Thenable<Definition>;
   findDocumentSymbols(document: TextDocument, doc: YAMLDocument): SymbolInformation[];
   doResolve(completionItem: CompletionItem): Thenable<CompletionItem>;
   resetSchema(uri: string): boolean;
@@ -120,6 +123,7 @@ export function getLanguageService(
 
   let completer = new YAMLCompletion(schemaService, contributions, promise);
   let hover = new YAMLHover(schemaService, contributions, promise);
+  let definition = new YAMLDefinition(schemaService, contributions, promise);
   let yamlDocumentSymbols = new YAMLDocumentSymbols();
   let yamlValidation = new YAMLValidation(schemaService, promise);
   let yamlTraversal = new YAMLTraversal(promise);
@@ -140,6 +144,7 @@ export function getLanguageService(
       doResolve: completer.doResolve.bind(completer),
       doValidation: yamlValidation.doValidation.bind(yamlValidation),
       doHover: hover.doHover.bind(hover),
+      doDefinition: definition.doDefinition.bind(definition),
       findDocumentSymbols: yamlDocumentSymbols.findDocumentSymbols.bind(yamlDocumentSymbols),
       resetSchema: (uri: string) => schemaService.onResourceChange(uri),
       doFormat: format,

--- a/language-service/src/yamlLanguageService.ts
+++ b/language-service/src/yamlLanguageService.ts
@@ -123,7 +123,7 @@ export function getLanguageService(
 
   let completer = new YAMLCompletion(schemaService, contributions, promise);
   let hover = new YAMLHover(schemaService, contributions, promise);
-  let definition = new YAMLDefinition(schemaService, contributions, promise);
+  let definition = new YAMLDefinition(promise);
   let yamlDocumentSymbols = new YAMLDocumentSymbols();
   let yamlValidation = new YAMLValidation(schemaService, promise);
   let yamlTraversal = new YAMLTraversal(promise);

--- a/language-service/tsconfig.json
+++ b/language-service/tsconfig.json
@@ -6,7 +6,10 @@
 		"moduleResolution": "node",
 		"sourceMap": true,
 		"declaration": true,
-		"lib" : [ "es2015", "dom" ],
+		"lib": [
+			"es2021",
+			"dom"
+		],
 		"outDir": "./lib",
 		"noUnusedLocals": true
 	},


### PR DESCRIPTION
## Motivation

My teams makes significant use of the [ADO Pipeline template paradigm](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/templates?view=azure-devops&pivots=templates-includes) and has many template references all over our pipeline definitions.

One of the most annoying things about this pattern is that when navigating around in VSCode, you need to select the full template path, copy it, and CTRL+P to open it in a new tab. Thus the motivation here is to have a seamless experience like in JS/TS where using F12 (or context clicking and selecting "Go To Definition") which takes you right to the template locally.

## Implementation

- added `definitionProvider` to the capabilities so this option will show on the menu and otherwise be available
- followed the paradigm of `hover` but with some modifications for the definition use case
  - when the definition flow is invoked, only `template` items will work
  - additionally, only non-suffixed templates, or templates suffixed with `@self` will work
- support relative & abs (from workspace root) template paths
- opens the template on the first line in first position
