### PR TITLE
Allow flow-style maps in sequences

### DIFF
--- a/language-service/src/parser/yamlParser.ts
+++ b/language-service/src/parser/yamlParser.ts
@@ -212,7 +212,7 @@ function addItemsToArrayNode(node: ArrayASTNode, items: Yaml.YAMLNode[]): void {
 			// Hoisted expressions must be the first (and only) property in an object,
 			// so we can safely check only the first key.
 			// TODO: Confirm the above statement.
-			if (item.kind === Yaml.Kind.MAP && isCompileTimeExpression(item.mappings[0])) {
+			if (item.kind === Yaml.Kind.MAP && item.mappings.length > 0 && isCompileTimeExpression(item.mappings[0])) {
 				const value = item.mappings[0].value;
 				if (value === null) {
 					// Incomplete object: they're still working on the value :).
@@ -247,8 +247,7 @@ function addItemsToArrayNode(node: ArrayASTNode, items: Yaml.YAMLNode[]): void {
 					itemNode = recursivelyBuildAst(node, value);
 				} else if (value.kind === Yaml.Kind.SCALAR) {
 					// False positive: no children. Add the item directly just like in the no-expression case.
-					// e.g. looping through an array parameter and using each one
-					// as a key or value.
+					// e.g. looping through an array parameter and using each one as a key or value.
 					// - ${{ each shorthand in parameters.taskShorthands }}:
 					//   - ${{ shorthand }}: echo 'Hi' <-- current item in the sequence
 					//                     ^ it's a map (object)

--- a/language-service/test/pipelinesTests/yamlvalidation.test.ts
+++ b/language-service/test/pipelinesTests/yamlvalidation.test.ts
@@ -108,23 +108,34 @@ steps:
         assert.equal(diagnostics.length, 0);
     });
 
-    it('validates pipelines that has an object with a dynamic key and scalar value as the first property', async function () {
-      // Note: the real purpose of this test is to ensure we don't throw,
-      // but I can't figure out how to assert that yet.
-      // diagnostics.length can be whatever, as long as we get to that point :).
-      const diagnostics = await runValidationTest(`
+    it('validates pipelines that have an object with a dynamic key and scalar value as the first property', async function () {
+        // Note: the real purpose of this test is to ensure we don't throw,
+        // but I can't figure out how to assert that yet.
+        // diagnostics.length can be whatever, as long as we get to that point :).
+        const diagnostics = await runValidationTest(`
 steps:
 - \${{ each shorthand in parameters.taskShorthands }}:
   - \${{ shorthand }}: echo 'Hi'
 `);
-      assert.equal(diagnostics.length, 2);
+        assert.equal(diagnostics.length, 2);
+    });
+
+    it('validates pipelines that are using flow-style mappings in an array', async function () {
+        // Note: the real purpose of this test is to ensure we don't throw,
+        // but I can't figure out how to assert that yet.
+        // diagnostics.length can be whatever, as long as we get to that point :).
+        const diagnostics = await runValidationTest(`
+variables:
+- { }
+`);
+        assert.equal(diagnostics.length, 1);
     });
 
     it('validates incorrectly-indented pipelines that look like they have an array property', async function () {
-      // Note: the real purpose of this test is to ensure we don't throw,
-      // but I can't figure out how to assert that yet.
-      // diagnostics.length can be whatever, as long as we get to that point :).
-      const diagnostics = await runValidationTest(`
+        // Note: the real purpose of this test is to ensure we don't throw,
+        // but I can't figure out how to assert that yet.
+        // diagnostics.length can be whatever, as long as we get to that point :).
+        const diagnostics = await runValidationTest(`
 steps:
 - task: PowerShellOnTargetMachines@3
   inputs:
@@ -133,7 +144,7 @@ steps:
     [System.Reflection.Assembly]::LoadWithPartialName("System.IO.Compression.FileSystem") | Out-Null
     CommunicationProtocol: Http);
 `);
-      assert.equal(diagnostics.length, 4);
+        assert.equal(diagnostics.length, 4);
     });
 });
 


### PR DESCRIPTION
The `{ }` started a map, but since there's nothing in it yet `item.mappings.length` was 0. Oops! 

Thankfully, this is a straightforward fix: ensure there's at least one mapping before we check it.

Fixes #167