### PR TITLE
Guard against null rootUris

### DIFF
--- a/language-server/src/server.ts
+++ b/language-server/src/server.ts
@@ -83,11 +83,11 @@ let hasWorkspaceFolderCapability = false;
 // in the passed params the rootPath of the workspace plus the client capabilities.
 let capabilities: ClientCapabilities;
 let workspaceFolders = [];
-let workspaceRoot: URI;
+let workspaceRoot: URI | undefined;
 connection.onInitialize((params: InitializeParams): InitializeResult => {
 	capabilities = params.capabilities;
 	workspaceFolders = params["workspaceFolders"];
-	workspaceRoot = URI.parse(params.rootUri, true);
+	workspaceRoot = params.rootUri ? URI.parse(params.rootUri, true) : undefined;
 
 	function hasClientCapability(...keys: string[]) {
 		let c = params.capabilities;

--- a/language-service/src/services/yamlDefinition.ts
+++ b/language-service/src/services/yamlDefinition.ts
@@ -21,7 +21,7 @@ export class YAMLDefinition {
         this.promise = promiseConstructor || Promise;
     }
 
-    public doDefinition(document: TextDocument, position: Position, yamlDocument: YAMLDocument, workspaceRoot: URI): Thenable<Definition> {
+    public doDefinition(document: TextDocument, position: Position, yamlDocument: YAMLDocument, workspaceRoot: URI | undefined): Thenable<Definition> {
         const offset = document.offsetAt(position);
 
         const jsonDocument = yamlDocument.documents.length > 0 ? yamlDocument.documents[0] : null;
@@ -64,8 +64,13 @@ export class YAMLDefinition {
         // So create an actual URI, then .toString() it and skip the unnecessary encoding.
         let definitionUri = '';
         if (location.startsWith(path.sep)) {
-            // Substring to strip the leading separator.
-            definitionUri = Utils.joinPath(workspaceRoot, location.substring(1)).toString(true);
+            if (workspaceRoot !== undefined) {
+                // Substring to strip the leading separator.
+                definitionUri = Utils.joinPath(workspaceRoot, location.substring(1)).toString(true);
+            } else {
+                // Can't form an absolute path without a workspace root.
+                return this.promise.resolve(void 0);
+            }
         }
         else {
             definitionUri = Utils.resolvePath(


### PR DESCRIPTION
rootUri can be null if no folder is open, in which case we want to degrade gracefully instead of outright crashing :).

Fix for microsoft/azure-pipelines-vscode#602.
Fixes #160