### PR TITLE
update network policies for release pipelines

### DIFF
--- a/.pipelines/release-server.yml
+++ b/.pipelines/release-server.yml
@@ -17,7 +17,7 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
     settings:
-      networkIsolationPolicy: Permissive,CFSClean
+      networkIsolationPolicy: Permissive
     sdl:
       sourceAnalysisPool:
         name: 1ES-ABTT-Shared-Pool

--- a/.pipelines/release-service.yml
+++ b/.pipelines/release-service.yml
@@ -17,7 +17,7 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
     settings:
-      networkIsolationPolicy: Permissive,CFSClean
+      networkIsolationPolicy: Permissive
     sdl:
       sourceAnalysisPool:
         name: 1ES-ABTT-Shared-Pool


### PR DESCRIPTION
This pull request makes a minor update to the pipeline configuration files by adjusting the network isolation policy settings. The change removes the `CFSClean` option from the `networkIsolationPolicy` parameter in both the server and service release pipelines.

- Pipeline configuration updates:
  * Removed `CFSClean` from the `networkIsolationPolicy` parameter, leaving only `Permissive` in `.pipelines/release-server.yml` and `.pipelines/release-service.yml`. [[1]](diffhunk://#diff-51557a6006f0b3d93c2b6319256a69606aab3cc2fcce2f957137f125b69fe0c6L20-R20) [[2]](diffhunk://#diff-06040ffc3601d38137872a5e7c642b67adda3a106cb8ee02530152d1185440aeL20-R20)