### PR TITLE
Route npm traffic through approved feeds

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+registry=https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/
+
+always-auth=true

--- a/.pipelines/release-server.yml
+++ b/.pipelines/release-server.yml
@@ -17,7 +17,7 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
     settings:
-      networkIsolationPolicy: Permissive
+      networkIsolationPolicy: Permissive,Npm
     sdl:
       sourceAnalysisPool:
         name: 1ES-ABTT-Shared-Pool

--- a/.pipelines/release-service.yml
+++ b/.pipelines/release-service.yml
@@ -17,7 +17,7 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
     settings:
-      networkIsolationPolicy: Permissive
+      networkIsolationPolicy: Permissive,Npm
     sdl:
       sourceAnalysisPool:
         name: 1ES-ABTT-Shared-Pool

--- a/language-server/src/server.ts
+++ b/language-server/src/server.ts
@@ -203,7 +203,6 @@ let schemaAssociations: ISchemaAssociations = void 0;
 let formatterRegistration: Thenable<Disposable> = null;
 let specificValidatorPaths = [];
 let schemaConfigurationSettings = [];
-let schemaStoreSettings = [];
 let customTags = [];
 
 connection.onDidChangeConfiguration((change) => {
@@ -239,41 +238,6 @@ connection.onDidChangeConfiguration((change) => {
 		}
 	}
 });
-
-function getSchemaStoreMatchingSchemas(){
-
-	return xhr({ url: "http://schemastore.org/api/json/catalog.json" }).then(response => {
-
-		let languageSettings= {
-			schemas: []
-		};
-
-		let schemas = JSON.parse(response.responseText);
-		for(let schemaIndex in schemas.schemas){
-
-			let schema = schemas.schemas[schemaIndex];
-			if(schema && schema.fileMatch){
-
-				for(let fileMatch in schema.fileMatch){
-					let currFileMatch = schema.fileMatch[fileMatch];
-
-					if(currFileMatch.indexOf('.yml') !== -1 || currFileMatch.indexOf('.yaml') !== -1){
-						languageSettings.schemas.push({ uri: schema.url, fileMatch: [currFileMatch] });
-					}
-
-				}
-
-			}
-
-		}
-
-		return languageSettings;
-
-	}, (error: XHRResponse) => {
-		throw error;
-	});
-
-}
 
 connection.onNotification(SchemaAssociationNotification.type, associations => {
 	schemaAssociations = associations;
@@ -314,9 +278,6 @@ function updateConfiguration() {
 				languageSettings = configureSchemas(uri, schema.fileMatch, schema.schema, languageSettings);
 			}
 		});
-	}
-	if(schemaStoreSettings){
-		languageSettings.schemas = languageSettings.schemas.concat(schemaStoreSettings);
 	}
 	customLanguageService.configure(languageSettings);
 

--- a/language-server/test/autoCompletion.test.ts
+++ b/language-server/test/autoCompletion.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { LanguageService, getLanguageService } from 'azure-pipelines-language-service'
-import { schemaRequestService, workspaceContext }  from './testHelper';
+import { schemaRequestService, testSchemaUri, workspaceContext }  from './testHelper';
 import { parse as parseYAML } from 'azure-pipelines-language-service';
 import { completionHelper } from 'azure-pipelines-language-service';
 var assert = require('assert');
@@ -12,7 +12,7 @@ var assert = require('assert');
 let languageService: LanguageService = getLanguageService(schemaRequestService, [], null, workspaceContext);
 
 
-let uri = 'http://json.schemastore.org/bowerrc';
+let uri = testSchemaUri;
 let languageSettings = {
 	schemas: []
 };

--- a/language-server/test/formatter.test.ts
+++ b/language-server/test/formatter.test.ts
@@ -4,13 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { getLanguageService } from 'azure-pipelines-language-service'
-import { schemaRequestService, workspaceContext } from './testHelper';
+import { schemaRequestService, testSchemaUri, workspaceContext } from './testHelper';
 var assert = require('assert');
 
 let languageService = getLanguageService(schemaRequestService, [], null, workspaceContext);
 
 
-let uri = 'http://json.schemastore.org/bowerrc';
+let uri = testSchemaUri;
 let languageSettings = {
     schemas: [],
     validate: true,

--- a/language-server/test/hover.test.ts
+++ b/language-server/test/hover.test.ts
@@ -5,7 +5,7 @@
 import { Hover, MarkupContent, MarkedString} from 'vscode-languageserver/node';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import {getLanguageService} from 'azure-pipelines-language-service'
-import {schemaRequestService, workspaceContext}  from './testHelper';
+import {schemaRequestService, testSchemaUri, workspaceContext}  from './testHelper';
 import { parse as parseYAML } from 'azure-pipelines-language-service';
 import { type } from 'os';
 var assert = require('assert');
@@ -13,7 +13,7 @@ var assert = require('assert');
 let languageService = getLanguageService(schemaRequestService, [], null, workspaceContext);
 
 
-let uri = 'http://json.schemastore.org/bowerrc';
+let uri = testSchemaUri;
 let languageSettings = {
 	schemas: []
 };

--- a/language-server/test/hover2.test.ts
+++ b/language-server/test/hover2.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import {getLanguageService} from 'azure-pipelines-language-service'
-import {schemaRequestService, workspaceContext}  from './testHelper';
+import {schemaRequestService, testSchemaUri, workspaceContext}  from './testHelper';
 import {assertHasContents} from './hover.test'
 import { parse as parseYAML } from 'azure-pipelines-language-service';
 var assert = require('assert');
@@ -12,7 +12,7 @@ var assert = require('assert');
 let languageService = getLanguageService(schemaRequestService, [], null, workspaceContext);
 
 
-let uri = 'http://json.schemastore.org/composer';
+let uri = testSchemaUri;
 let languageSettings = {
 	schemas: []
 };

--- a/language-server/test/schemaValidation.test.ts
+++ b/language-server/test/schemaValidation.test.ts
@@ -4,13 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import {getLanguageService} from 'azure-pipelines-language-service'
-import {schemaRequestService, workspaceContext}  from './testHelper';
+import {schemaRequestService, testSchemaUri, workspaceContext}  from './testHelper';
 import { parse as parseYAML } from 'azure-pipelines-language-service';
 var assert = require('assert');
 
 let languageService = getLanguageService(schemaRequestService, [], null, workspaceContext);
 
-let uri = 'http://json.schemastore.org/bowerrc';
+let uri = testSchemaUri;
 let languageSettings = {
 	schemas: [],
 	validate: true,

--- a/language-server/test/test.schema.json
+++ b/language-server/test/test.schema.json
@@ -1,0 +1,85 @@
+{
+  "type": "object",
+  "properties": {
+    "analytics": {
+      "type": "boolean",
+      "description": "Enable analytics."
+    },
+    "authors": {
+      "type": "array",
+      "description": "Package authors.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Author name."
+          },
+          "email": {
+            "type": "string",
+            "description": "Author email."
+          }
+        }
+      }
+    },
+    "cwd": {
+      "type": "string",
+      "description": "Working directory."
+    },
+    "customize": {
+      "type": "string"
+    },
+    "directory": {
+      "type": "string",
+      "default": "bower_components"
+    },
+    "license": {
+      "type": [
+        "string",
+        "array"
+      ]
+    },
+    "registry": {
+      "type": "object",
+      "properties": {
+        "register": {
+          "type": "string"
+        },
+        "search": {
+          "type": "string"
+        }
+      }
+    },
+    "resolvers": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "scripts": {
+      "type": "object",
+      "description": "Lifecycle scripts.",
+      "properties": {
+        "postinstall": {
+          "type": "string",
+          "description": "Command to run after installation."
+        },
+        "preinstall": {
+          "type": "string",
+          "description": "Command to run before installation."
+        }
+      },
+      "additionalProperties": {
+        "type": "string",
+        "description": "Lifecycle script command."
+      }
+    },
+    "storage": {
+      "type": "object"
+    },
+    "timeout": {
+      "type": "number",
+      "default": 60000
+    }
+  }
+}

--- a/language-server/test/testHelper.ts
+++ b/language-server/test/testHelper.ts
@@ -48,6 +48,12 @@ export let workspaceContext = {
 	}
 };
 
+let testSchemaPath = __dirname.replace("\\", "/");
+if (!testSchemaPath.startsWith("/")) {
+	testSchemaPath = "/" + testSchemaPath;
+}
+export const testSchemaUri = 'file://' + testSchemaPath + '/test.schema.json';
+
 export const schemaRequestService = async (uri: string): Promise<JSONSchema> => {
 	if (Strings.startsWith(uri, 'file://')) {
 		const fsPath = URI.parse(uri).fsPath;

--- a/language-server/test/testHelper.ts
+++ b/language-server/test/testHelper.ts
@@ -48,7 +48,7 @@ export let workspaceContext = {
 	}
 };
 
-let testSchemaPath = __dirname.replace("\\", "/");
+let testSchemaPath = __dirname.replace(/\\/g, "/");
 if (!testSchemaPath.startsWith("/")) {
 	testSchemaPath = "/" + testSchemaPath;
 }

--- a/language-service/README.md
+++ b/language-service/README.md
@@ -41,7 +41,7 @@ yaml.schemas: {
 e.g.
 ```
 yaml.schemas: {
-    "http://json.schemastore.org/composer": "/*"
+    "file:///path/to/schema.json": "/*"
 }
 ```
 
@@ -62,7 +62,7 @@ yaml.schemas: {
 e.g.
 ```
 yaml.schemas: {
-    "http://json.schemastore.org/composer": "/*",
+    "file:///path/to/schema.json": "/*",
     "kubernetes": "/myYamlFile.yaml"
 }
 ```


### PR DESCRIPTION
## Summary
- configure the repository root to install npm packages through the Azure DevOps feed
- replace network-dependent SchemaStore test schemas with a local fixture and remove the unused product catalog integration
- allow npm network access in the server and service release pipelines for publishing to npmjs.org

## Validation
- language server build and all 104 tests pass
- language service build and all 30 tests pass
- package lockfiles contain no npmjs registry references