### PR TITLE
Migrate npm releases to ESRP

### DIFF
--- a/.pipelines/build-package.yml
+++ b/.pipelines/build-package.yml
@@ -33,8 +33,8 @@ jobs:
   - script: npm ci
     displayName: npm ci
     workingDirectory: ${{ parameters.root }}
-  - script: npm run build
-    displayName: Build and generate a package
+  - script: npm run build:pipeline
+    displayName: Build package contents
     workingDirectory: ${{ parameters.root }}
   - script: npx mocha --require ts-node/register --ui bdd ./test/**/*.test.ts --reporter mocha-junit-reporter
     displayName: Run tests

--- a/.pipelines/build-package.yml
+++ b/.pipelines/build-package.yml
@@ -1,21 +1,23 @@
-# This Yaml Document has been converted by ESAI Yaml Pipeline Conversion Tool.
-# Please make sure to check all the converted content, it is your team's responsibility to make sure that the pipeline is still valid and functions as expected.
-# The Task 'PublishBuildArtifacts@1' has been converted to an output named 'Save the npm module' in the templateContext section.
+# Reusable package build and test job. Release builds also create the
+# same-run npm-packages artifact consumed by ESRP.
 parameters:
   name: ''
   root: ''
-  packagename: ''
-  tarballPath: ''
   configuration: ''
 jobs:
 - job: ${{ parameters.name }}
-  templateContext:
-    outputs:
-    - output: pipelineArtifact
-      displayName: 'Save the npm module'
-      targetPath: ${{ format('$(Build.ArtifactStagingDirectory)/{0}', parameters.packageName) }}
-      artifactName: ${{ parameters.packagename }}
+  ${{ if eq(parameters.configuration, 'release') }}:
+    templateContext:
+      outputs:
+      - output: pipelineArtifact
+        displayName: 'Publish npm package (.tgz)'
+        targetPath: '$(Build.ArtifactStagingDirectory)/npm-packages'
+        artifactName: npm-packages
   steps:
+  - task: UseNode@1
+    displayName: Install Node 20.20.0
+    inputs:
+      version: '20.20.0'
   - bash: |
       PACKAGE_VERSION=$(node -p "require('./package.json').version")
       echo "$PACKAGE_VERSION" > version.txt
@@ -24,10 +26,10 @@ jobs:
   - template: /.pipelines/${{ format('version-{0}.yml', parameters.configuration) }}@self
     parameters:
       root: ${{ parameters.root }}
-  - task: UseNode@1
-    displayName: Install Node 20.20.0
+  - task: NpmAuthenticate@0
+    displayName: Authenticate npm
     inputs:
-      version: "20.20.0"
+      workingFile: ${{ format('{0}/.npmrc', parameters.root) }}
   - script: npm ci
     displayName: npm ci
     workingDirectory: ${{ parameters.root }}
@@ -43,14 +45,9 @@ jobs:
     inputs:
       testRunner: JUnit
       testResultsFiles: ${{ format('./{0}/test-results.xml', parameters.root) }}
-  - task: CopyFiles@2
-    displayName: Stage the npm module
-    inputs:
-      sourceFolder: ${{ parameters.tarballPath }}
-      contents: '*.tgz'
-      targetFolder: ${{ format('$(Build.ArtifactStagingDirectory)/{0}', parameters.packageName) }}
   - ${{ if eq( parameters.configuration, 'release') }}:
     - bash: |
+        set -euo pipefail
         echo $(Build.SourceBranch) | sed "s|refs/[^/]*/||" > branch.txt
         PACKAGE_VERSION=$(cat version.txt)
         VERSION_REGEX="#### $(echo $PACKAGE_VERSION | sed 's/\./\\./g')"
@@ -63,6 +60,35 @@ jobs:
       workingDirectory: ${{ parameters.root }}
       displayName: Get branch and mini-changelog
   - ${{ if eq( parameters.configuration, 'release') }}:
+    - bash: |
+        set -euo pipefail
+        node -e "const p=require('./package.json'); if (p.private===true) { console.error('ERROR: package.json is marked private; refusing to pack.'); process.exit(1); }"
+        mkdir -p "$(Build.ArtifactStagingDirectory)/npm-packages/packages"
+        rm -f "$(Build.ArtifactStagingDirectory)/npm-packages/packages"/*.tgz
+        npm pack --pack-destination "$(Build.ArtifactStagingDirectory)/npm-packages/packages"
+      displayName: Pack npm module
+      workingDirectory: ${{ parameters.root }}
+    - bash: |
+        set -euo pipefail
+        shopt -s nullglob
+        packages=("$(Build.ArtifactStagingDirectory)/npm-packages/packages"/*.tgz)
+        count=${#packages[@]}
+        echo "Found $count .tgz file(s)."
+        if [ "$count" -ne 1 ]; then
+          echo "ERROR: expected exactly one .tgz file, found $count."
+          exit 1
+        fi
+      displayName: Verify exactly one npm package exists
+    - bash: |
+        set -euo pipefail
+        for tgz in "$(Build.ArtifactStagingDirectory)/npm-packages/packages"/*.tgz; do
+          entries=$(tar -tzf "$tgz")
+          if grep -E '(^|/)_manifest/' <<< "$entries"; then
+            echo "ERROR: $tgz contains an SBOM _manifest/ folder."
+            exit 1
+          fi
+        done
+      displayName: Verify package excludes SBOM manifest
     - task: CopyFiles@2
       displayName: Stage release meta-data files
       inputs:
@@ -71,33 +97,4 @@ jobs:
           version.txt
           branch.txt
           minichangelog.txt
-        targetFolder: ${{ format('$(Build.ArtifactStagingDirectory)/{0}', parameters.packageName) }}
-  - ${{ if eq( parameters.configuration, 'release') }}:
-    - bash: npm install
-      displayName: Prepare to create GitHub Release
-      workingDirectory: '$(Build.SourcesDirectory)/.pipelines/github-release'
-  # Publish to npm only after every release gate above (changelog validation, etc.)
-  # has passed, since publishing is irreversible.
-  - ${{ if eq( parameters.configuration, 'release') }}:
-    - script: |
-        set -euo pipefail
-        npm config set //registry.npmjs.org/:_authToken "$NPM_TOKEN"
-        npm publish "${{ parameters.packagename }}-$(cat version.txt).tgz" --registry https://registry.npmjs.org/ --access public
-      displayName: Publish package to npm
-      workingDirectory: ${{ parameters.root }}
-      env:
-        NPM_TOKEN: $(npm-automation.token)
-  - ${{ if eq( parameters.configuration, 'release') }}:
-    - bash: |
-        SCRIPT=.pipelines/github-release/github-release.js
-        PACKAGE_VERSION=$(cat $STAGE_DIR/version.txt)
-        CONTENT=$STAGE_DIR/$PACKAGE_NAME-$PACKAGE_VERSION.tgz
-        CHANGELOG=$STAGE_DIR/minichangelog.txt
-        VERSION_TAG=$PACKAGE_NAME/v$PACKAGE_VERSION
-        node $SCRIPT $CONTENT $CHANGELOG $VERSION_TAG $GITHUB_TOKEN
-      displayName: Create GitHub Release
-      continueOnError: true
-      env:
-        GITHUB_TOKEN: $(GitHubSecret)
-        STAGE_DIR: ${{ format('$(Build.ArtifactStagingDirectory)/{0}', parameters.packageName) }}
-        PACKAGE_NAME: ${{ parameters.packageName }}
+        targetFolder: '$(Build.ArtifactStagingDirectory)/npm-packages/release-metadata'

--- a/.pipelines/pipeline.yml
+++ b/.pipelines/pipeline.yml
@@ -30,13 +30,9 @@ extends:
         parameters:
           name: 'build_language_service'
           root: 'language-service'
-          packagename: 'azure-pipelines-language-service'
-          tarballPath: 'language-service'
           configuration: 'ci'
       - template: /.pipelines/build-package.yml@self
         parameters:
           name: 'build_language_server'
           root: 'language-server'
-          packagename: 'azure-pipelines-language-server'
-          tarballPath: 'language-server'
           configuration: 'ci'

--- a/.pipelines/release-package.yml
+++ b/.pipelines/release-package.yml
@@ -1,0 +1,93 @@
+parameters:
+  name: ''
+  root: ''
+  packagename: ''
+
+stages:
+- stage: BuildAndPack
+  displayName: Build, test, and pack
+  jobs:
+  - template: /.pipelines/build-package.yml@self
+    parameters:
+      name: ${{ parameters.name }}
+      root: ${{ parameters.root }}
+      configuration: release
+
+- stage: PublishToNpmViaESRP
+  displayName: Publish to npm via ESRP
+  dependsOn: BuildAndPack
+  jobs:
+  - job: esrp
+    displayName: ESRP Release (npm)
+    pool:
+      name: 1ES-ABTT-Shared-Pool
+      image: abtt-windows-2025
+      os: windows
+    templateContext:
+      type: releaseJob
+      isProduction: true
+      inputs:
+      - input: pipelineArtifact
+        artifactName: npm-packages
+        targetPath: $(Pipeline.Workspace)/npm-packages
+    steps:
+    - task: EsrpRelease@12
+      displayName: Publish package to npm via ESRP
+      inputs:
+        connectedservicename: '$(EsrpServiceConnection)'
+        usemanagedidentity: true
+        keyvaultname: '$(EsrpKeyVault)'
+        signcertname: '$(EsrpSignCert)'
+        clientid: '$(EsrpClientId)'
+        intent: PackageDistribution
+        contenttype: npm
+        contentsource: Folder
+        folderlocation: '$(Pipeline.Workspace)/npm-packages/packages'
+        waitforreleasecompletion: true
+        owners: '$(EsrpOwners)'
+        approvers: '$(EsrpApprovers)'
+        serviceendpointurl: '$(EsrpServiceEndpointUrl)'
+        mainpublisher: '$(EsrpMainPublisher)'
+        domaintenantid: '$(EsrpDomainTenantId)'
+
+- stage: CreateGitHubRelease
+  displayName: Create GitHub Release
+  dependsOn: PublishToNpmViaESRP
+  jobs:
+  - job: github_release
+    displayName: Create GitHub Release
+    pool:
+      name: 1ES-ABTT-Shared-Pool
+      image: abtt-ubuntu-2404
+      os: linux
+    templateContext:
+      inputs:
+      - input: pipelineArtifact
+        artifactName: npm-packages
+        targetPath: $(Pipeline.Workspace)/npm-packages
+    steps:
+    - task: UseNode@1
+      displayName: Install Node 20.20.0
+      inputs:
+        version: '20.20.0'
+    - task: NpmAuthenticate@0
+      displayName: Authenticate npm
+      inputs:
+        workingFile: .pipelines/github-release/.npmrc
+    - script: npm ci
+      displayName: Install GitHub Release dependencies
+      workingDirectory: .pipelines/github-release
+    - bash: |
+        set -euo pipefail
+        SCRIPT=.pipelines/github-release/github-release.js
+        METADATA_DIR="$(Pipeline.Workspace)/npm-packages/release-metadata"
+        PACKAGE_VERSION=$(cat "$METADATA_DIR/version.txt")
+        CONTENT="$(Pipeline.Workspace)/npm-packages/packages/${PACKAGE_NAME}-${PACKAGE_VERSION}.tgz"
+        CHANGELOG="$METADATA_DIR/minichangelog.txt"
+        VERSION_TAG="${PACKAGE_NAME}/v${PACKAGE_VERSION}"
+        node "$SCRIPT" "$CONTENT" "$CHANGELOG" "$VERSION_TAG" "$GITHUB_TOKEN"
+      displayName: Create GitHub Release
+      continueOnError: true
+      env:
+        GITHUB_TOKEN: $(GitHubSecret)
+        PACKAGE_NAME: ${{ parameters.packagename }}

--- a/.pipelines/release-package.yml
+++ b/.pipelines/release-package.yml
@@ -1,7 +1,16 @@
 parameters:
-  name: ''
-  root: ''
-  packagename: ''
+- name: name
+  type: string
+  default: ''
+- name: root
+  type: string
+  default: ''
+- name: packagename
+  type: string
+  default: ''
+- name: dryRun
+  type: boolean
+  default: false
 
 stages:
 - stage: BuildAndPack
@@ -13,81 +22,82 @@ stages:
       root: ${{ parameters.root }}
       configuration: release
 
-- stage: PublishToNpmViaESRP
-  displayName: Publish to npm via ESRP
-  dependsOn: BuildAndPack
-  jobs:
-  - job: esrp
-    displayName: ESRP Release (npm)
-    pool:
-      name: 1ES-ABTT-Shared-Pool
-      image: abtt-windows-2025
-      os: windows
-    templateContext:
-      type: releaseJob
-      isProduction: true
-      inputs:
-      - input: pipelineArtifact
-        artifactName: npm-packages
-        targetPath: $(Pipeline.Workspace)/npm-packages
-    steps:
-    - task: EsrpRelease@12
-      displayName: Publish package to npm via ESRP
-      inputs:
-        connectedservicename: '$(EsrpServiceConnection)'
-        usemanagedidentity: true
-        keyvaultname: '$(EsrpKeyVault)'
-        signcertname: '$(EsrpSignCert)'
-        clientid: '$(EsrpClientId)'
-        intent: PackageDistribution
-        contenttype: npm
-        contentsource: Folder
-        folderlocation: '$(Pipeline.Workspace)/npm-packages/packages'
-        waitforreleasecompletion: true
-        owners: '$(EsrpOwners)'
-        approvers: '$(EsrpApprovers)'
-        serviceendpointurl: '$(EsrpServiceEndpointUrl)'
-        mainpublisher: '$(EsrpMainPublisher)'
-        domaintenantid: '$(EsrpDomainTenantId)'
+- ${{ if eq(parameters.dryRun, false) }}:
+  - stage: PublishToNpmViaESRP
+    displayName: Publish to npm via ESRP
+    dependsOn: BuildAndPack
+    jobs:
+    - job: esrp
+      displayName: ESRP Release (npm)
+      pool:
+        name: 1ES-ABTT-Shared-Pool
+        image: abtt-windows-2025
+        os: windows
+      templateContext:
+        type: releaseJob
+        isProduction: true
+        inputs:
+        - input: pipelineArtifact
+          artifactName: npm-packages
+          targetPath: $(Pipeline.Workspace)/npm-packages
+      steps:
+      - task: EsrpRelease@12
+        displayName: Publish package to npm via ESRP
+        inputs:
+          connectedservicename: '$(EsrpServiceConnection)'
+          usemanagedidentity: true
+          keyvaultname: '$(EsrpKeyVault)'
+          signcertname: '$(EsrpSignCert)'
+          clientid: '$(EsrpClientId)'
+          intent: PackageDistribution
+          contenttype: npm
+          contentsource: Folder
+          folderlocation: '$(Pipeline.Workspace)/npm-packages/packages'
+          waitforreleasecompletion: true
+          owners: '$(EsrpOwners)'
+          approvers: '$(EsrpApprovers)'
+          serviceendpointurl: '$(EsrpServiceEndpointUrl)'
+          mainpublisher: '$(EsrpMainPublisher)'
+          domaintenantid: '$(EsrpDomainTenantId)'
 
-- stage: CreateGitHubRelease
-  displayName: Create GitHub Release
-  dependsOn: PublishToNpmViaESRP
-  jobs:
-  - job: github_release
+  - stage: CreateGitHubRelease
     displayName: Create GitHub Release
-    pool:
-      name: 1ES-ABTT-Shared-Pool
-      image: abtt-ubuntu-2404
-      os: linux
-    templateContext:
-      inputs:
-      - input: pipelineArtifact
-        artifactName: npm-packages
-        targetPath: $(Pipeline.Workspace)/npm-packages
-    steps:
-    - task: UseNode@1
-      displayName: Install Node 20.20.0
-      inputs:
-        version: '20.20.0'
-    - task: NpmAuthenticate@0
-      displayName: Authenticate npm
-      inputs:
-        workingFile: .pipelines/github-release/.npmrc
-    - script: npm ci
-      displayName: Install GitHub Release dependencies
-      workingDirectory: .pipelines/github-release
-    - bash: |
-        set -euo pipefail
-        SCRIPT=.pipelines/github-release/github-release.js
-        METADATA_DIR="$(Pipeline.Workspace)/npm-packages/release-metadata"
-        PACKAGE_VERSION=$(cat "$METADATA_DIR/version.txt")
-        CONTENT="$(Pipeline.Workspace)/npm-packages/packages/${PACKAGE_NAME}-${PACKAGE_VERSION}.tgz"
-        CHANGELOG="$METADATA_DIR/minichangelog.txt"
-        VERSION_TAG="${PACKAGE_NAME}/v${PACKAGE_VERSION}"
-        node "$SCRIPT" "$CONTENT" "$CHANGELOG" "$VERSION_TAG" "$GITHUB_TOKEN"
+    dependsOn: PublishToNpmViaESRP
+    jobs:
+    - job: github_release
       displayName: Create GitHub Release
-      continueOnError: true
-      env:
-        GITHUB_TOKEN: $(GitHubSecret)
-        PACKAGE_NAME: ${{ parameters.packagename }}
+      pool:
+        name: 1ES-ABTT-Shared-Pool
+        image: abtt-ubuntu-2404
+        os: linux
+      templateContext:
+        inputs:
+        - input: pipelineArtifact
+          artifactName: npm-packages
+          targetPath: $(Pipeline.Workspace)/npm-packages
+      steps:
+      - task: UseNode@1
+        displayName: Install Node 20.20.0
+        inputs:
+          version: '20.20.0'
+      - task: NpmAuthenticate@0
+        displayName: Authenticate npm
+        inputs:
+          workingFile: .pipelines/github-release/.npmrc
+      - script: npm ci
+        displayName: Install GitHub Release dependencies
+        workingDirectory: .pipelines/github-release
+      - bash: |
+          set -euo pipefail
+          SCRIPT=.pipelines/github-release/github-release.js
+          METADATA_DIR="$(Pipeline.Workspace)/npm-packages/release-metadata"
+          PACKAGE_VERSION=$(cat "$METADATA_DIR/version.txt")
+          CONTENT="$(Pipeline.Workspace)/npm-packages/packages/${PACKAGE_NAME}-${PACKAGE_VERSION}.tgz"
+          CHANGELOG="$METADATA_DIR/minichangelog.txt"
+          VERSION_TAG="${PACKAGE_NAME}/v${PACKAGE_VERSION}"
+          node "$SCRIPT" "$CONTENT" "$CHANGELOG" "$VERSION_TAG" "$GITHUB_TOKEN"
+        displayName: Create GitHub Release
+        continueOnError: true
+        env:
+          GITHUB_TOKEN: $(GitHubSecret)
+          PACKAGE_NAME: ${{ parameters.packagename }}

--- a/.pipelines/release-server.yml
+++ b/.pipelines/release-server.yml
@@ -6,7 +6,13 @@
 trigger: none
 pr: none
 variables:
-- group: npm-tokens
+- group: esrp-npm-release
+- name: EsrpMainPublisher
+  value: 'ESRPRELPACMAN'
+- name: EsrpServiceEndpointUrl
+  value: 'https://api.esrp.microsoft.com'
+- name: EsrpDomainTenantId
+  value: '975f013f-7f24-47e8-a7d3-abc4752bf346'
 resources:
   repositories:
   - repository: 1ESPipelineTemplates
@@ -21,21 +27,17 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: 1ES-ABTT-Shared-Pool
-        image: abtt-windows-2022
+        image: abtt-windows-2025
         os: windows
     pool:
       name: 1ES-ABTT-Shared-Pool
-      image: abtt-ubuntu-2204
+      image: abtt-ubuntu-2404
       os: linux
     customBuildTags:
     - ES365AIMigrationTooling
     stages:
-    - stage: stage
-      jobs:
-      - template: /.pipelines/build-package.yml@self
-        parameters:
-          name: 'build_language_server'
-          root: 'language-server'
-          packagename: 'azure-pipelines-language-server'
-          tarballPath: 'language-server'
-          configuration: 'release'
+    - template: /.pipelines/release-package.yml@self
+      parameters:
+        name: 'build_language_server'
+        root: 'language-server'
+        packagename: 'azure-pipelines-language-server'

--- a/.pipelines/release-server.yml
+++ b/.pipelines/release-server.yml
@@ -13,12 +13,6 @@ trigger: none
 pr: none
 variables:
 - group: esrp-npm-release
-- name: EsrpMainPublisher
-  value: 'ESRPRELPACMAN'
-- name: EsrpServiceEndpointUrl
-  value: 'https://api.esrp.microsoft.com'
-- name: EsrpDomainTenantId
-  value: '975f013f-7f24-47e8-a7d3-abc4752bf346'
 resources:
   repositories:
   - repository: 1ESPipelineTemplates

--- a/.pipelines/release-server.yml
+++ b/.pipelines/release-server.yml
@@ -3,6 +3,12 @@
 
 # Release build script for language-server
 # Only trigger manually
+parameters:
+- name: dryRun
+  displayName: Build and validate without publishing
+  type: boolean
+  default: false
+
 trigger: none
 pr: none
 variables:
@@ -41,3 +47,4 @@ extends:
         name: 'build_language_server'
         root: 'language-server'
         packagename: 'azure-pipelines-language-server'
+        dryRun: ${{ parameters.dryRun }}

--- a/.pipelines/release-service.yml
+++ b/.pipelines/release-service.yml
@@ -3,6 +3,12 @@
 
 # Release build script for language-service
 # Only trigger manually
+parameters:
+- name: dryRun
+  displayName: Build and validate without publishing
+  type: boolean
+  default: false
+
 trigger: none
 pr: none
 variables:
@@ -41,3 +47,4 @@ extends:
         name: 'build_language_service'
         root: 'language-service'
         packagename: 'azure-pipelines-language-service'
+        dryRun: ${{ parameters.dryRun }}

--- a/.pipelines/release-service.yml
+++ b/.pipelines/release-service.yml
@@ -13,12 +13,6 @@ trigger: none
 pr: none
 variables:
 - group: esrp-npm-release
-- name: EsrpMainPublisher
-  value: 'ESRPRELPACMAN'
-- name: EsrpServiceEndpointUrl
-  value: 'https://api.esrp.microsoft.com'
-- name: EsrpDomainTenantId
-  value: '975f013f-7f24-47e8-a7d3-abc4752bf346'
 resources:
   repositories:
   - repository: 1ESPipelineTemplates

--- a/.pipelines/release-service.yml
+++ b/.pipelines/release-service.yml
@@ -6,7 +6,13 @@
 trigger: none
 pr: none
 variables:
-- group: npm-tokens
+- group: esrp-npm-release
+- name: EsrpMainPublisher
+  value: 'ESRPRELPACMAN'
+- name: EsrpServiceEndpointUrl
+  value: 'https://api.esrp.microsoft.com'
+- name: EsrpDomainTenantId
+  value: '975f013f-7f24-47e8-a7d3-abc4752bf346'
 resources:
   repositories:
   - repository: 1ESPipelineTemplates
@@ -21,21 +27,17 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: 1ES-ABTT-Shared-Pool
-        image: abtt-windows-2022
+        image: abtt-windows-2025
         os: windows
     pool:
       name: 1ES-ABTT-Shared-Pool
-      image: abtt-ubuntu-2204
+      image: abtt-ubuntu-2404
       os: linux
     customBuildTags:
     - ES365AIMigrationTooling
     stages:
-    - stage: stage
-      jobs:
-      - template: /.pipelines/build-package.yml@self
-        parameters:
-          name: 'build_language_service'
-          root: 'language-service'
-          packagename: 'azure-pipelines-language-service'
-          tarballPath: 'language-service'
-          configuration: 'release'
+    - template: /.pipelines/release-package.yml@self
+      parameters:
+        name: 'build_language_service'
+        root: 'language-service'
+        packagename: 'azure-pipelines-language-service'

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,7 @@
 # Release process
 
+The service and server release pipelines publish by default. To validate a release without publishing, set **Build and validate without publishing** (`dryRun`) to `true` when queueing either pipeline. A dry run performs the complete build, test, pack, tarball-count, and `_manifest/` validation flow, but does not run ESRP or create a GitHub Release.
+
 1. Choose your new target version number. For this, we'll use "0.1.2".
 2. Make a branch to ship from. `git switch -c ship-0.1.2`
 3. Release the service first. `cd language-service`

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,7 +6,7 @@
     1. Bump the language-service version. `npm version --no-git-tag-version 0.1.2`
     2. Ensure there's an entry for this new version in the service `changelog.md`.
     3. Commit and push. `git commit -am "version service" && git push -u origin ship-0.1.2`
-    4. **This step creates a GitHub Release and publishes the package to npm** Run the [service release pipeline][release-service], targeting your ship branch. (NB: make sure you're logged into Azure DevOps. It's a public project so you can view it anonymously, and may have to explicitly log in from the upper right.) 
+    4. **This step publishes the package to npm through ESRP, then creates a GitHub Release.** Run the [service release pipeline][release-service], targeting your ship branch, and complete the ESRP approval. (NB: make sure you're logged into Azure DevOps. It's a public project so you can view it anonymously, and may have to explicitly log in from the upper right.)
     5. Verify the new version is live on npm and that the GitHub release was created.
 4. Bump the dependency in the server.
     1. Get to the right directory. `cd ../language-server`
@@ -15,7 +15,7 @@
     1. Bump the language-server version. `npm version --no-git-tag-version 0.1.2`
     2. Ensure there's an entry for this new version in the server `changelog.md`. (TODO/improvement: we should hardlink the server/service changelog files, as there's never a time when they should differ.)
     3. Commit and push. `git commit -am "version server" && git push -u origin ship-0.1.2`
-    4. **This step creates a GitHub Release and publishes the package to npm** Run the [server release pipeline][release-server], targeting your ship branch. The pipeline publishes to npm automatically; no manual `npm publish` is required.
+    4. **This step publishes the package to npm through ESRP, then creates a GitHub Release.** Run the [server release pipeline][release-server], targeting your ship branch, and complete the ESRP approval.
     5. Verify the new version is live on npm and that the GitHub release was created.
 6. Create a PR from your ship branch to `main`. Merge it. :tada: you're done!
 

--- a/language-server/package.json
+++ b/language-server/package.json
@@ -60,7 +60,7 @@
     "serialize-javascript": "7.0.5"
   },
   "scripts": {
-    "build": "npm run compile && npm pack",
+    "build": "npm run compile",
     "compile": "tsc -p .",
     "watch": "tsc -watch -p .",
     "test": "mocha --require ts-node/register --ui bdd ./test/**/*.test.ts",

--- a/language-server/package.json
+++ b/language-server/package.json
@@ -60,7 +60,8 @@
     "serialize-javascript": "7.0.5"
   },
   "scripts": {
-    "build": "npm run compile",
+    "build": "npm run compile && npm pack",
+    "build:pipeline": "npm run compile",
     "compile": "tsc -p .",
     "watch": "tsc -watch -p .",
     "test": "mocha --require ts-node/register --ui bdd ./test/**/*.test.ts",

--- a/language-service/package.json
+++ b/language-service/package.json
@@ -67,7 +67,8 @@
     "js-yaml": "4.2.0"
   },
   "scripts": {
-    "build": "npm run clean && npm run compile && webpack --mode production",
+    "build": "npm run clean && npm run compile && webpack --mode production && npm pack",
+    "build:pipeline": "npm run clean && npm run compile && webpack --mode production",
     "compile": "tsc -p .",
     "watch": "tsc -watch -p .",
     "clean": "rimraf lib _bundles",

--- a/language-service/package.json
+++ b/language-service/package.json
@@ -67,7 +67,7 @@
     "js-yaml": "4.2.0"
   },
   "scripts": {
-    "build": "npm run clean && npm run compile && webpack --mode production && npm pack",
+    "build": "npm run clean && npm run compile && webpack --mode production",
     "compile": "tsc -p .",
     "watch": "tsc -watch -p .",
     "clean": "rimraf lib _bundles",


### PR DESCRIPTION
## Summary
- replace direct npm publication with a shared `EsrpRelease@12` release flow
- build and pack each release into the same-run `npm-packages/packages` artifact, with exact-count and `_manifest/` guards
- preserve the existing developer-facing `npm run build` behavior, including local `npm pack`
- use `build:pipeline` in CI before the explicit ESRP-targeted staged pack
- remove `npm-tokens`, `NPM_TOKEN`, and `npm-automation.token` usage
- create GitHub Releases only after ESRP completes
- retain separate service and server release pipelines so the service can be published before its dependent server package
- add a `dryRun` boolean parameter to both manual release pipelines

## Dry-run usage
Queue either release pipeline with **Build and validate without publishing** (`dryRun`) set to `true`. The pipeline runs the full `BuildAndPack` stage, including build, tests, `npm pack`, the exact-one-tarball guard, and the `_manifest/` guard, but compile-time omits both the ESRP publish stage and the GitHub Release stage. The parameter defaults to `false`, preserving normal release behavior.

## Validation
- language service: developer build-and-pack and pipeline build/staged-pack paths
- language server: developer build-and-pack and pipeline build/staged-pack paths
- language service: 75 tests; language server: 104 tests
- all pipeline YAML parsed successfully
- both service and server release YAML validated for `dryRun: false` (`BuildAndPack` -> ESRP -> GitHub Release) and `dryRun: true` (`BuildAndPack` only)
- ESRP artifact/task contract and removed secret references audited

## Manual onboarding required
Before either release pipeline can publish, install the ESRP Release extension, approve/register the publisher identity, configure the Key Vault signing certificate and `Key Vault Certificate User` role, create the WIF Azure RM service connection, confirm npm allow-list/publish rights for both packages, and create the `esrp-npm-release` variable group with the required ESRP values.

---
Related work item: AB#2440593