### PR TITLE
package version updates to fix vulnerabilities

### DIFF
--- a/language-server/CHANGELOG.md
+++ b/language-server/CHANGELOG.md
@@ -1,3 +1,6 @@
+#### 0.9.1
+- Version update to enable package publishing through ESRP. [PR#192](https://github.com/microsoft/azure-pipelines-language-server/pull/192)
+
 #### 0.9.0
 - Updated `azure-pipelines-language-service` dependency to 0.9.0, which updates `js-yaml`, `mocha`, and `webpack` to patched versions and adds a `serialize-javascript` override to fix vulnerabilities [#PR-179](https://github.com/microsoft/azure-pipelines-language-server/pull/179) and [#PR-180](https://github.com/microsoft/azure-pipelines-language-server/pull/180)
 

--- a/language-server/CHANGELOG.md
+++ b/language-server/CHANGELOG.md
@@ -1,5 +1,6 @@
 #### 0.9.1
-- Version update to enable package publishing through ESRP. [PR#192](https://github.com/microsoft/azure-pipelines-language-server/pull/192)
+- Updated `js-yaml` and `brace-expansion` packages to patched versions to fix vulnerabilities [PR#192](https://github.com/microsoft/azure-pipelines-language-server/pull/192)
+
 
 #### 0.9.0
 - Updated `azure-pipelines-language-service` dependency to 0.9.0, which updates `js-yaml`, `mocha`, and `webpack` to patched versions and adds a `serialize-javascript` override to fix vulnerabilities [#PR-179](https://github.com/microsoft/azure-pipelines-language-server/pull/179) and [#PR-180](https://github.com/microsoft/azure-pipelines-language-server/pull/180)

--- a/language-server/package-lock.json
+++ b/language-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "azure-pipelines-language-server",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "azure-pipelines-language-server",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "azure-pipelines-language-service": "0.9.0",

--- a/language-server/package-lock.json
+++ b/language-server/package-lock.json
@@ -589,9 +589,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha1-xoscQRHHaq46b7pV1JbO4Qw52tg=",
+      "version": "2.1.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha1-WJ2rEcABjQNmvmTNi/Esjb7MgyY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1571,9 +1571,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha1-K9noVoLdkb1GmvuAnYFgQ7PUlSQ=",
+      "version": "4.3.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha1-ASFsAB1n9I4s1WDXCMevIQkKOEg=",
       "funding": [
         {
           "type": "github",
@@ -1873,9 +1873,9 @@
       }
     },
     "node_modules/nyc/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha1-ptkNVAZyNuX0JXCjtzeNWU2bdzg=",
+      "version": "1.1.18",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha1-POdNiYhRNr4VNTQfjD1EJcKaXKs=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2346,9 +2346,9 @@
       }
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha1-ptkNVAZyNuX0JXCjtzeNWU2bdzg=",
+      "version": "1.1.18",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha1-POdNiYhRNr4VNTQfjD1EJcKaXKs=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2570,9 +2570,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha1-ptkNVAZyNuX0JXCjtzeNWU2bdzg=",
+      "version": "1.1.18",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha1-POdNiYhRNr4VNTQfjD1EJcKaXKs=",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/language-server/package.json
+++ b/language-server/package.json
@@ -56,7 +56,9 @@
     "typescript": "~4.4.4"
   },
   "overrides": {
-    "js-yaml": "4.2.0",
+    "js-yaml": "4.3.1",
+    "brace-expansion@1.x": {".": "^1.1.18"},
+    "brace-expansion@2.x": {".": "^2.1.4"},
     "serialize-javascript": "7.0.5"
   },
   "scripts": {

--- a/language-server/package.json
+++ b/language-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "azure-pipelines-language-server",
   "description": "Azure Pipelines language server",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "author": "Microsoft",
   "license": "MIT",
   "contributors": [

--- a/language-service/CHANGELOG.md
+++ b/language-service/CHANGELOG.md
@@ -1,3 +1,6 @@
+#### 0.9.1
+- Updated `js-yaml`, `brace-expansion` and `fast-uri` packages to patched versions to fix vulnerabilities [PR#192](https://github.com/microsoft/azure-pipelines-language-server/pull/192)
+
 #### 0.9.0
 - Updated `js-yaml`, `mocha`, and `webpack` to patched versions and added a `serialize-javascript` override to fix vulnerabilities [#PR-179](https://github.com/microsoft/azure-pipelines-language-server/pull/179) and [#PR-180](https://github.com/microsoft/azure-pipelines-language-server/pull/180)
 

--- a/language-service/package-lock.json
+++ b/language-service/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "azure-pipelines-language-service",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "azure-pipelines-language-service",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
-        "js-yaml": "4.2.0",
+        "js-yaml": "^4.3.1",
         "jsonc-parser": "2.0.2",
         "vscode-json-languageservice": "^4.0.2",
         "vscode-languageserver-types": "^3.16.0",
@@ -918,9 +918,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha1-xoscQRHHaq46b7pV1JbO4Qw52tg=",
+      "version": "2.1.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha1-WJ2rEcABjQNmvmTNi/Esjb7MgyY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1496,9 +1496,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha1-ivPU/J0+cbEVcswmc7UUp9GoyOw=",
+      "version": "3.1.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha1-YQ83QZoDAnBDDOzWjXTj1NlnJdA=",
       "dev": true,
       "funding": [
         {
@@ -2206,9 +2206,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha1-K9noVoLdkb1GmvuAnYFgQ7PUlSQ=",
+      "version": "4.3.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha1-ASFsAB1n9I4s1WDXCMevIQkKOEg=",
       "funding": [
         {
           "type": "github",
@@ -2607,9 +2607,9 @@
       }
     },
     "node_modules/nyc/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha1-ptkNVAZyNuX0JXCjtzeNWU2bdzg=",
+      "version": "1.1.18",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha1-POdNiYhRNr4VNTQfjD1EJcKaXKs=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3172,9 +3172,9 @@
       }
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha1-ptkNVAZyNuX0JXCjtzeNWU2bdzg=",
+      "version": "1.1.18",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha1-POdNiYhRNr4VNTQfjD1EJcKaXKs=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3549,9 +3549,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha1-ptkNVAZyNuX0JXCjtzeNWU2bdzg=",
+      "version": "1.1.18",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha1-POdNiYhRNr4VNTQfjD1EJcKaXKs=",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/language-service/package-lock.json
+++ b/language-service/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "azure-pipelines-language-service",
-  "version": "0.10.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "azure-pipelines-language-service",
-      "version": "0.10.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.3.1",

--- a/language-service/package.json
+++ b/language-service/package.json
@@ -1,7 +1,7 @@
 {
   "name": "azure-pipelines-language-service",
   "description": "Azure Pipelines language service",
-  "version": "0.10.0",
+  "version": "0.9.1",
   "author": "Microsoft",
   "license": "MIT",
   "main": "./lib/index.js",

--- a/language-service/package.json
+++ b/language-service/package.json
@@ -65,9 +65,9 @@
   "overrides": {
     "serialize-javascript": "7.0.5",
     "js-yaml": "^4.3.1",
-    "brace-expansion@1.x": {".": "1.1.18"},
-    "brace-expansion@2.x": {".": "2.1.4"},
-    "fast-uri@3.x": {".": "3.1.5"}
+    "brace-expansion@1.x": {".": "^1.1.18"},
+    "brace-expansion@2.x": {".": "^2.1.4"},
+    "fast-uri@3.x": {".": "^3.1.5"}
   },
   "scripts": {
     "build": "npm run clean && npm run compile && webpack --mode production && npm pack",

--- a/language-service/package.json
+++ b/language-service/package.json
@@ -1,7 +1,7 @@
 {
   "name": "azure-pipelines-language-service",
   "description": "Azure Pipelines language service",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "author": "Microsoft",
   "license": "MIT",
   "main": "./lib/index.js",
@@ -36,7 +36,7 @@
     "url": "https://github.com/microsoft/azure-pipelines-language-server.git"
   },
   "dependencies": {
-    "js-yaml": "4.2.0",
+    "js-yaml": "^4.3.1",
     "jsonc-parser": "2.0.2",
     "vscode-json-languageservice": "^4.0.2",
     "vscode-languageserver-types": "^3.16.0",
@@ -64,7 +64,10 @@
   },
   "overrides": {
     "serialize-javascript": "7.0.5",
-    "js-yaml": "4.2.0"
+    "js-yaml": "^4.3.1",
+    "brace-expansion@1.x": {".": "1.1.18"},
+    "brace-expansion@2.x": {".": "2.1.4"},
+    "fast-uri@3.x": {".": "3.1.5"}
   },
   "scripts": {
     "build": "npm run clean && npm run compile && webpack --mode production && npm pack",


### PR DESCRIPTION
AB#2447438
AB#2445585
AB#2445586

Vulnerability fixes for the language-service package
js-yaml, brace-expansion and fast-uri

Risk Assessment: Low

Language server version bumped to 0.9.1 to allow for ESRP exceptions.
Once the language service package 0.9.1 is published the language server will be updated to use the 0.9.1 language service and version will be change to 0.9.2 and published again.

If required at a later time will again bump versions of both the packages to make sure they are in sync. 
Right now the out of order ESRP publishing is causing the mismatch